### PR TITLE
Aman 85/read certification

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/controller/CertificateController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/CertificateController.java
@@ -1,0 +1,42 @@
+package rencanakan.id.talentpool.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import rencanakan.id.talentpool.dto.CertificateResponseDTO;
+import rencanakan.id.talentpool.dto.WebResponse;
+import rencanakan.id.talentpool.service.CertificateService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/certificates")
+public class CertificateController {
+    
+    private final CertificateService certificateService;
+
+    public CertificateController(CertificateService certificateService) {
+        this.certificateService = certificateService;
+    }
+    
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<WebResponse<List<CertificateResponseDTO>>> getCertificatesByUserId(
+            @PathVariable("userId") String userId,
+            @RequestHeader("Authorization") String token) {
+
+        List<CertificateResponseDTO> certificates = certificateService.getByUserId(userId);
+        return ResponseEntity.ok(WebResponse.<List<CertificateResponseDTO>>builder()
+                .data(certificates)
+                .build());
+    }
+    
+    @GetMapping("/{certificateId}")
+    public ResponseEntity<WebResponse<CertificateResponseDTO>> getCertificateById(
+            @PathVariable("certificateId") Long certificateId,
+            @RequestHeader("Authorization") String token) {
+
+        CertificateResponseDTO certificate = certificateService.getById(certificateId);
+        return ResponseEntity.ok(WebResponse.<CertificateResponseDTO>builder()
+                .data(certificate)
+                .build());
+    }
+}

--- a/src/main/java/rencanakan/id/talentpool/repository/CertificateRepository.java
+++ b/src/main/java/rencanakan/id/talentpool/repository/CertificateRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface CertificateRepository extends JpaRepository<Certificate, Long> {
-    List<Certificate> findByUserId(String talentId);
+    List<Certificate> findByUserId(String userId);
 }

--- a/src/main/java/rencanakan/id/talentpool/repository/CertificateRepository.java
+++ b/src/main/java/rencanakan/id/talentpool/repository/CertificateRepository.java
@@ -1,0 +1,12 @@
+package rencanakan.id.talentpool.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import rencanakan.id.talentpool.model.Certificate;
+
+import java.util.List;
+
+@Repository
+public interface CertificateRepository extends JpaRepository<Certificate, Long> {
+    List<Certificate> findByUserId(String talentId);
+}

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
@@ -1,0 +1,10 @@
+package rencanakan.id.talentpool.service;
+
+import rencanakan.id.talentpool.dto.CertificateResponseDTO;
+
+import java.util.List;
+
+public interface CertificateService {
+    List<CertificateResponseDTO> getByUserId(String talentId);
+    CertificateResponseDTO getById(Long certificateId);
+}

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
@@ -9,7 +9,6 @@ import rencanakan.id.talentpool.model.Certificate;
 import rencanakan.id.talentpool.repository.CertificateRepository;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class CertificateServiceImpl implements CertificateService {
@@ -29,8 +28,8 @@ public class CertificateServiceImpl implements CertificateService {
         }
 
         return certificates.stream()
-                .map(certificate -> DTOMapper.map(certificate, CertificateResponseDTO.class))
-                .collect(Collectors.toList());
+            .map(certificate -> DTOMapper.map(certificate, CertificateResponseDTO.class))
+            .toList();
     }
 
     @Override

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
@@ -1,0 +1,44 @@
+package rencanakan.id.talentpool.service;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.persistence.EntityNotFoundException;
+import rencanakan.id.talentpool.dto.CertificateResponseDTO;
+import rencanakan.id.talentpool.mapper.DTOMapper;
+import rencanakan.id.talentpool.model.Certificate;
+import rencanakan.id.talentpool.repository.CertificateRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CertificateServiceImpl implements CertificateService {
+
+    private final CertificateRepository certificateRepository;
+
+    public CertificateServiceImpl(CertificateRepository certificateRepository) {
+        this.certificateRepository = certificateRepository;
+    }
+
+    @Override
+    public List<CertificateResponseDTO> getByUserId(String talentId) {
+
+        List<Certificate> certificates = certificateRepository.findByUserId(talentId);
+        if (certificates.isEmpty()) {
+            throw new EntityNotFoundException("Certificates not found for user with id " + talentId);
+        }
+
+        return certificates.stream()
+                .map(certificate -> DTOMapper.map(certificate, CertificateResponseDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CertificateResponseDTO getById(Long certificateId) {
+
+        Certificate certificate = certificateRepository.findById(certificateId)
+                .orElseThrow(() -> new EntityNotFoundException("Certificate with id " + certificateId + " not found"));
+
+        return DTOMapper.map(certificate, CertificateResponseDTO.class);
+    }
+}

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
@@ -1,0 +1,122 @@
+package rencanakan.id.talentpool.unit.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import rencanakan.id.talentpool.controller.CertificateController;
+import rencanakan.id.talentpool.dto.CertificateResponseDTO;
+import rencanakan.id.talentpool.service.CertificateService;
+
+@ExtendWith(MockitoExtension.class)
+public class CertificateControllerTest {
+    
+    @Mock
+    private CertificateService certificateService;
+    
+    @InjectMocks
+    private CertificateController certificateController;
+    
+    private MockMvc mockMvc;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(certificateController)
+                .build();
+    }
+    
+    @Nested
+    class ReadCertificateTests {
+        
+        private String token;
+        private String talentId;
+        private Long certificateId;
+        private List<CertificateResponseDTO> certificateList;
+        private CertificateResponseDTO certificate;
+        
+        @BeforeEach
+        void setUp() {
+            token = "Bearer token";
+            talentId = "talent-123";
+            certificateId = 1L;
+            
+            certificate = new CertificateResponseDTO();
+            certificate.setId(certificateId);
+            certificate.setTitle("Java Certificate");
+            certificate.setFile("certificate.pdf");
+            certificate.setTalentId(talentId);
+            
+            certificateList = new ArrayList<>();
+            certificateList.add(certificate);
+        }
+        
+        @Test
+        void getCertificatesByUserId_ShouldReturnCertificates() throws Exception {
+            when(certificateService.getByUserId(talentId)).thenReturn(certificateList);
+            
+            mockMvc.perform(get("/certificates/user/{userId}", talentId)
+                    .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id").value(certificateId))
+                .andExpect(jsonPath("$.data[0].title").value("Java Certificate"))
+                .andExpect(jsonPath("$.data[0].file").value("certificate.pdf"));
+            
+            verify(certificateService, times(1)).getByUserId(talentId);
+        }
+        
+        @Test
+        void getCertificatesByUserId_WhenNoCertificates_ShouldReturnEmptyList() throws Exception {
+            List<CertificateResponseDTO> emptyList = new ArrayList<>();
+            when(certificateService.getByUserId(talentId)).thenReturn(emptyList);
+            
+            mockMvc.perform(get("/certificates/user/{userId}", talentId)
+                    .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(0)));
+            
+            verify(certificateService, times(1)).getByUserId(talentId);
+        }
+        
+        @Test
+        void getCertificateById_ShouldReturnCertificate() throws Exception {
+            when(certificateService.getById(certificateId)).thenReturn(certificate);
+            
+            mockMvc.perform(get("/certificates/{id}", certificateId)
+                    .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(certificateId))
+                .andExpect(jsonPath("$.data.title").value("Java Certificate"))
+                .andExpect(jsonPath("$.data.file").value("certificate.pdf"));
+            
+            verify(certificateService, times(1)).getById(certificateId);
+        }
+        
+        @Test
+        void getCertificateById_WhenNotFound_ShouldReturnNotFound() throws Exception {
+            when(certificateService.getById(certificateId)).thenReturn(null);
+            
+            mockMvc.perform(get("/certificates/{id}", certificateId)
+                    .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+            
+            verify(certificateService, times(1)).getById(certificateId);
+        }
+    }
+}

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
@@ -23,7 +23,7 @@ import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 import rencanakan.id.talentpool.service.CertificateService;
 
 @ExtendWith(MockitoExtension.class)
-public class CertificateControllerTest {
+class CertificateControllerTest {
     
     @Mock
     private CertificateService certificateService;

--- a/src/test/java/rencanakan/id/talentpool/unit/dto/RecommendationRequestDTOTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/dto/RecommendationRequestDTOTest.java
@@ -1,4 +1,4 @@
-package rencanakan.id.talentpool.dto;
+package rencanakan.id.talentpool.unit.dto;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -6,6 +6,8 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import rencanakan.id.talentpool.dto.RecommendationRequestDTO;
 import rencanakan.id.talentpool.enums.StatusType;
 
 import java.util.Set;

--- a/src/test/java/rencanakan/id/talentpool/unit/dto/RecommendationResponseDTOTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/dto/RecommendationResponseDTOTest.java
@@ -1,6 +1,8 @@
-package rencanakan.id.talentpool.dto;
+package rencanakan.id.talentpool.unit.dto;
 
 import org.junit.jupiter.api.Test;
+
+import rencanakan.id.talentpool.dto.RecommendationResponseDTO;
 import rencanakan.id.talentpool.enums.StatusType;
 import rencanakan.id.talentpool.model.User;
 

--- a/src/test/java/rencanakan/id/talentpool/unit/model/CertificateTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/model/CertificateTest.java
@@ -1,9 +1,12 @@
-package rencanakan.id.talentpool.model;
+package rencanakan.id.talentpool.unit.model;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import rencanakan.id.talentpool.model.Certificate;
+import rencanakan.id.talentpool.model.User;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/rencanakan/id/talentpool/unit/model/RecommendationTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/model/RecommendationTest.java
@@ -1,4 +1,4 @@
-package rencanakan.id.talentpool.model;
+package rencanakan.id.talentpool.unit.model;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import rencanakan.id.talentpool.enums.StatusType;
+import rencanakan.id.talentpool.model.Recommendation;
+import rencanakan.id.talentpool.model.User;
 
 import java.util.Set;
 import java.util.UUID;

--- a/src/test/java/rencanakan/id/talentpool/unit/repository/CertificateRepositoryTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/repository/CertificateRepositoryTest.java
@@ -76,14 +76,14 @@ class CertificateRepositoryTest {
                     .file("java-cert.pdf")
                     .user(testUser)
                     .build();
-            certificate1 = entityManager.persistAndFlush(certificate1);
+            entityManager.persistAndFlush(certificate1);
             
             Certificate certificate2 = Certificate.builder()
                     .title("Python Certificate")
                     .file("python-cert.pdf")
                     .user(testUser)
                     .build();
-            certificate2 = entityManager.persistAndFlush(certificate2);
+            entityManager.persistAndFlush(certificate2);
             
             List<Certificate> certificates = certificateRepository.findByUserId(testUserId);
             

--- a/src/test/java/rencanakan/id/talentpool/unit/repository/CertificateRepositoryTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/repository/CertificateRepositoryTest.java
@@ -1,0 +1,141 @@
+package rencanakan.id.talentpool.unit.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import rencanakan.id.talentpool.model.Certificate;
+import rencanakan.id.talentpool.model.User;
+import rencanakan.id.talentpool.repository.CertificateRepository;
+import rencanakan.id.talentpool.repository.UserRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class CertificateRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private CertificateRepository certificateRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    
+    
+    @Nested
+    class ReadCertificateTests {
+        private User testUser;
+        private String testUserId;
+        
+        @BeforeEach
+        void setUp() {
+            certificateRepository.deleteAll();
+            userRepository.deleteAll();
+            
+            testUser = createUser();
+            testUser = entityManager.persistAndFlush(testUser);
+            testUserId = testUser.getId();
+        }
+
+        private User createUser() {
+            return User.builder()
+                    .firstName("John")
+                    .lastName("Doe")
+                    .email("john.doe@example.com")
+                    .password("password123")
+                    .phoneNumber("1234567890")
+                    .photo("profile.jpg")
+                    .aboutMe("About me text")
+                    .nik("1234567890123456")
+                    .npwp("12.345.678.9-012.345")
+                    .photoKtp("ktp.jpg")
+                    .photoNpwp("npwp.jpg")
+                    .photoIjazah("ijazah.jpg")
+                    .experienceYears(5)
+                    .skkLevel("Intermediate")
+                    .currentLocation("Jakarta")
+                    .preferredLocations(Arrays.asList("Jakarta", "Bandung"))
+                    .skill("Java, Spring Boot")
+                    .build();
+        }
+        
+        @Test
+        void findByUserId_WithExistingCertificates_ShouldReturnList() {
+            Certificate certificate1 = Certificate.builder()
+                    .title("Java Certificate")
+                    .file("java-cert.pdf")
+                    .user(testUser)
+                    .build();
+            certificate1 = entityManager.persistAndFlush(certificate1);
+            
+            Certificate certificate2 = Certificate.builder()
+                    .title("Python Certificate")
+                    .file("python-cert.pdf")
+                    .user(testUser)
+                    .build();
+            certificate2 = entityManager.persistAndFlush(certificate2);
+            
+            List<Certificate> certificates = certificateRepository.findByUserId(testUserId);
+            
+            assertNotNull(certificates);
+            assertEquals(2, certificates.size());
+            assertTrue(certificates.stream().anyMatch(cert -> cert.getTitle().equals("Java Certificate")));
+            assertTrue(certificates.stream().anyMatch(cert -> cert.getTitle().equals("Python Certificate")));
+        }
+        
+        @Test
+        void findByUserId_WithNonExistingTalent_ShouldReturnEmptyList() {
+            List<Certificate> certificates = certificateRepository.findByUserId("non-existing-id");
+            
+            assertNotNull(certificates);
+            assertTrue(certificates.isEmpty());
+        }
+        
+        @Test
+        void findByUserId_WithNoCertificates_ShouldReturnEmptyList() {
+            List<Certificate> certificates = certificateRepository.findByUserId(testUserId);
+            
+            assertNotNull(certificates);
+            assertTrue(certificates.isEmpty());
+        }
+
+        @Test
+        void findById_WithExistingCertificate_ShouldReturnCertificate() {
+            Certificate certificate = Certificate.builder()
+                    .title("Java Certificate")
+                    .file("java-cert.pdf")
+                    .user(testUser)
+                    .build();
+            
+            Certificate savedCertificate = certificateRepository.save(certificate);
+            
+            Optional<Certificate> result = certificateRepository.findById(savedCertificate.getId());
+    
+            assertTrue(result.isPresent());
+            assertEquals("Java Certificate", result.get().getTitle());
+            assertEquals("java-cert.pdf", result.get().getFile());
+        }
+        
+        @Test
+        void findById_WithNonExistingId_ShouldReturnEmpty() {
+            Optional<Certificate> result = certificateRepository.findById(999L);
+            
+            assertFalse(result.isPresent());
+        }
+        
+        @Test
+        void findById_WithNullId_ShouldThrowException() {
+            assertThrows(Exception.class, () -> certificateRepository.findById(null));
+        }
+    }
+}

--- a/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
@@ -28,7 +28,7 @@ import rencanakan.id.talentpool.repository.CertificateRepository;
 import rencanakan.id.talentpool.service.CertificateServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
-public class CertificateServiceTest {
+class CertificateServiceTest {
 
     @Mock
     private CertificateRepository certificateRepository;

--- a/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
@@ -40,6 +40,7 @@ class CertificateServiceTest {
     @Nested
     class ReadCertificateTests {
         private User user;
+        private String userId;
         private Certificate certificate;
         private CertificateResponseDTO certificateResponseDTO;
     
@@ -65,6 +66,8 @@ class CertificateServiceTest {
                     .preferredLocations(Arrays.asList("Jakarta", "Bandung"))
                     .skill("Java, Spring Boot")
                     .build();
+
+            userId = user.getId();
     
             certificate = Certificate.builder()
                     .id(1L)
@@ -103,7 +106,7 @@ class CertificateServiceTest {
             when(certificateRepository.findByUserId(user.getId())).thenReturn(Collections.emptyList());
             
             EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, 
-                    () -> certificateService.getByUserId(user.getId()));
+                    () -> certificateService.getByUserId(userId));
             
             assertEquals("Certificates not found for user with id talent-123", exception.getMessage());
             verify(certificateRepository).findByUserId(user.getId());

--- a/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
@@ -1,0 +1,171 @@
+package rencanakan.id.talentpool.unit.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.persistence.EntityNotFoundException;
+import rencanakan.id.talentpool.dto.CertificateResponseDTO;
+import rencanakan.id.talentpool.mapper.DTOMapper;
+import rencanakan.id.talentpool.model.Certificate;
+import rencanakan.id.talentpool.model.User;
+import rencanakan.id.talentpool.repository.CertificateRepository;
+import rencanakan.id.talentpool.service.CertificateServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class CertificateServiceTest {
+
+    @Mock
+    private CertificateRepository certificateRepository;
+
+    @InjectMocks
+    private CertificateServiceImpl certificateService;
+
+    
+    @Nested
+    class ReadCertificateTests {
+        private User user;
+        private Certificate certificate;
+        private CertificateResponseDTO certificateResponseDTO;
+    
+        @BeforeEach
+        void setUp() {
+            user = User.builder()
+                    .id("talent-123")
+                    .firstName("John")
+                    .lastName("Doe")
+                    .email("john.doe@example.com")
+                    .password("password123")
+                    .phoneNumber("1234567890")
+                    .photo("profile.jpg")
+                    .aboutMe("About me text")
+                    .nik("1234567890123456")
+                    .npwp("12.345.678.9-012.345")
+                    .photoKtp("ktp.jpg")
+                    .photoNpwp("npwp.jpg")
+                    .photoIjazah("ijazah.jpg")
+                    .experienceYears(5)
+                    .skkLevel("Intermediate")
+                    .currentLocation("Jakarta")
+                    .preferredLocations(Arrays.asList("Jakarta", "Bandung"))
+                    .skill("Java, Spring Boot")
+                    .build();
+    
+            certificate = Certificate.builder()
+                    .id(1L)
+                    .title("Java Certificate")
+                    .file("java-cert.pdf")
+                    .user(user)
+                    .build();
+    
+            certificateResponseDTO = new CertificateResponseDTO();
+            certificateResponseDTO.setId(1L);
+            certificateResponseDTO.setTitle("Java Certificate");
+            certificateResponseDTO.setFile("java-cert.pdf");
+        }
+        
+        @Test
+        void getByTalentId_WithExistingCertificates_ShouldReturnDTOList() {
+            List<Certificate> certificates = List.of(certificate);
+            when(certificateRepository.findByUserId(user.getId())).thenReturn(certificates);
+            
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                dtoMapperMock.when(() -> DTOMapper.map(any(Certificate.class), eq(CertificateResponseDTO.class)))
+                    .thenReturn(certificateResponseDTO);
+                
+                List<CertificateResponseDTO> result = certificateService.getByUserId(user.getId());
+                
+                assertNotNull(result);
+                assertEquals(1, result.size());
+                assertEquals("Java Certificate", result.get(0).getTitle());
+            }
+            
+            verify(certificateRepository).findByUserId(user.getId());
+        }
+        
+        @Test
+        void getByTalentId_WithNoCertificates_ShouldThrowEntityNotFoundException() {
+            when(certificateRepository.findByUserId(user.getId())).thenReturn(Collections.emptyList());
+            
+            EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, 
+                    () -> certificateService.getByUserId(user.getId()));
+            
+            assertEquals("Certificates not found for user with id talent-123", exception.getMessage());
+            verify(certificateRepository).findByUserId(user.getId());
+        }
+        
+        @Test
+        void getByTalentId_WithNullId_ShouldHandleNullPointerException() {
+            when(certificateRepository.findByUserId(null)).thenThrow(NullPointerException.class);
+            
+            assertThrows(NullPointerException.class, () -> certificateService.getByUserId(null));
+            verify(certificateRepository).findByUserId(null);
+        }
+
+        @Test
+        void getById_WithExistingId_ShouldReturnDTO() {
+            when(certificateRepository.findById(1L)).thenReturn(Optional.of(certificate));
+            
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                dtoMapperMock.when(() -> DTOMapper.map(certificate, CertificateResponseDTO.class))
+                    .thenReturn(certificateResponseDTO);
+                
+                CertificateResponseDTO result = certificateService.getById(1L);
+                
+                assertNotNull(result);
+                assertEquals(1L, result.getId());
+                assertEquals("Java Certificate", result.getTitle());
+            }
+            
+            verify(certificateRepository).findById(1L);
+        }
+        
+        @Test
+        void getById_WithNonExistingId_ShouldThrowEntityNotFoundException() {
+            when(certificateRepository.findById(999L)).thenReturn(Optional.empty());
+            
+            EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, 
+                    () -> certificateService.getById(999L));
+            
+            assertEquals("Certificate with id 999 not found", exception.getMessage());
+            verify(certificateRepository).findById(999L);
+        }
+        
+        @Test
+        void getById_WithNullId_ShouldHandleNullPointerException() {
+            when(certificateRepository.findById(null)).thenThrow(IllegalArgumentException.class);
+            
+            assertThrows(IllegalArgumentException.class, () -> certificateService.getById(null));
+            verify(certificateRepository).findById(null);
+        }
+        
+        @Test
+        void getById_WhenMapperFails_ShouldPropagateException() {
+            when(certificateRepository.findById(1L)).thenReturn(Optional.of(certificate));
+            
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                dtoMapperMock.when(() -> DTOMapper.map(certificate, CertificateResponseDTO.class))
+                    .thenThrow(RuntimeException.class);
+                
+                assertThrows(RuntimeException.class, () -> certificateService.getById(1L));
+            }
+            
+            verify(certificateRepository).findById(1L);
+        }
+    }
+}


### PR DESCRIPTION
# Description  
Read certification, with id and by talent id

# Ticket Issue 
https://a-man-ppl.atlassian.net/browse/AMAN-85?atlOrigin=eyJpIjoiNDYzMDY3ZTUyNzIzNGI5NDg4Mzg2ODA1YTYzYzhkYTIiLCJwIjoiaiJ9

# Changes Made  
Add implementation for read certification, with id and talent id

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [X] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [X] 🔍 Testing

# Added/updated tests?
- [X] Yes
- [ ] No

# Additional Notes  
100% coverage code

# (optional) What photo/gif best describes this PR or how it makes you feel?
HAPPY!!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new certificate management endpoints to enable secure retrieval of certificate data. Users can now fetch a list of their certificates and view detailed information for a specific certificate.
  - Enhanced error responses ensure clear feedback when certificate data isn’t found, improving reliability and overall user experience.

- **Tests**
  - Added unit tests for the `CertificateController`, `CertificateRepository`, and `CertificateServiceImpl` to validate functionality and ensure reliability of the new features. 
  - Included tests for various scenarios in the `CertificateService` and `CertificateRepository` to confirm expected behaviors and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->