### PR TITLE
Aman 39/create certificate

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/controller/CertificateController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/CertificateController.java
@@ -1,10 +1,14 @@
 package rencanakan.id.talentpool.controller;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import rencanakan.id.talentpool.dto.CertificateRequestDTO;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 import rencanakan.id.talentpool.dto.WebResponse;
 import rencanakan.id.talentpool.service.CertificateService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import rencanakan.id.talentpool.model.User;
 
 import java.util.List;
 
@@ -37,6 +41,17 @@ public class CertificateController {
         CertificateResponseDTO certificate = certificateService.getById(certificateId);
         return ResponseEntity.ok(WebResponse.<CertificateResponseDTO>builder()
                 .data(certificate)
+                .build());
+    }
+
+    @PostMapping
+    public ResponseEntity<WebResponse<CertificateResponseDTO>> createCertificate(
+            @RequestBody @Valid CertificateRequestDTO certificateRequest,
+            @AuthenticationPrincipal User user) {
+
+        CertificateResponseDTO createdCertificate = certificateService.create(user.getId(), certificateRequest);
+        return ResponseEntity.ok(WebResponse.<CertificateResponseDTO>builder()
+                .data(createdCertificate)
                 .build());
     }
 }

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface CertificateService {
     List<CertificateResponseDTO> getByUserId(String talentId);
     CertificateResponseDTO getById(Long certificateId);
+    CertificateResponseDTO create(String userId, CertificateResponseDTO certificateRequest);
 }

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
@@ -1,6 +1,5 @@
 package rencanakan.id.talentpool.service;
 
-import rencanakan.id.talentpool.dto.CertificateRequestDTO;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 
 import java.util.List;
@@ -8,5 +7,5 @@ import java.util.List;
 public interface CertificateService {
     List<CertificateResponseDTO> getByUserId(String talentId);
     CertificateResponseDTO getById(Long certificateId);
-    CertificateResponseDTO create(String userId, CertificateRequestDTO certificateRequest);
+    CertificateResponseDTO create(String userId, CertificateResponseDTO certificateRequest);
 }

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateService.java
@@ -1,5 +1,6 @@
 package rencanakan.id.talentpool.service;
 
+import rencanakan.id.talentpool.dto.CertificateRequestDTO;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 
 import java.util.List;
@@ -7,5 +8,5 @@ import java.util.List;
 public interface CertificateService {
     List<CertificateResponseDTO> getByUserId(String talentId);
     CertificateResponseDTO getById(Long certificateId);
-    CertificateResponseDTO create(String userId, CertificateResponseDTO certificateRequest);
+    CertificateResponseDTO create(String userId, CertificateRequestDTO certificateRequest);
 }

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
@@ -4,7 +4,6 @@ import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 
 import jakarta.persistence.EntityNotFoundException;
-import rencanakan.id.talentpool.dto.CertificateRequestDTO;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 import rencanakan.id.talentpool.mapper.DTOMapper;
 import rencanakan.id.talentpool.model.Certificate;
@@ -45,7 +44,7 @@ public class CertificateServiceImpl implements CertificateService {
     }
 
     @Override
-    public CertificateResponseDTO create(String userId, @Valid CertificateRequestDTO certificateRequest) {
+    public CertificateResponseDTO create(String userId, @Valid CertificateResponseDTO certificateRequest) {
 
         if (userId == null || certificateRequest == null) {
             throw new IllegalArgumentException("Certification request cannot be null");

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 
 import jakarta.persistence.EntityNotFoundException;
+import rencanakan.id.talentpool.dto.CertificateRequestDTO;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 import rencanakan.id.talentpool.mapper.DTOMapper;
 import rencanakan.id.talentpool.model.Certificate;
@@ -44,7 +45,7 @@ public class CertificateServiceImpl implements CertificateService {
     }
 
     @Override
-    public CertificateResponseDTO create(String userId, @Valid CertificateResponseDTO certificateRequest) {
+    public CertificateResponseDTO create(String userId, @Valid CertificateRequestDTO certificateRequest) {
 
         if (userId == null || certificateRequest == null) {
             throw new IllegalArgumentException("Certification request cannot be null");

--- a/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/CertificateServiceImpl.java
@@ -1,11 +1,13 @@
 package rencanakan.id.talentpool.service;
 
+import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 
 import jakarta.persistence.EntityNotFoundException;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
 import rencanakan.id.talentpool.mapper.DTOMapper;
 import rencanakan.id.talentpool.model.Certificate;
+import rencanakan.id.talentpool.model.User;
 import rencanakan.id.talentpool.repository.CertificateRepository;
 
 import java.util.List;
@@ -39,5 +41,19 @@ public class CertificateServiceImpl implements CertificateService {
                 .orElseThrow(() -> new EntityNotFoundException("Certificate with id " + certificateId + " not found"));
 
         return DTOMapper.map(certificate, CertificateResponseDTO.class);
+    }
+
+    @Override
+    public CertificateResponseDTO create(String userId, @Valid CertificateResponseDTO certificateRequest) {
+
+        if (userId == null || certificateRequest == null) {
+            throw new IllegalArgumentException("Certification request cannot be null");
+        }
+
+        Certificate newCertificate = DTOMapper.map(certificateRequest, Certificate.class);
+        newCertificate.setUser(User.builder().id(userId).build());
+
+        Certificate savedCertificate = certificateRepository.save(newCertificate);
+        return DTOMapper.map(savedCertificate, CertificateResponseDTO.class);
     }
 }

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -41,9 +40,6 @@ import java.util.List;
 @ExtendWith(MockitoExtension.class)
 class CertificateControllerTest {
 
-    // Add Mockito rule to allow lenient stubbing
-//    @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
-
     @Mock
     private CertificateService certificateService;
 
@@ -66,14 +62,9 @@ class CertificateControllerTest {
         mockMvc = MockMvcBuilders
                 .standaloneSetup(certificateController)
                 .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
-//                .setControllerAdvice(new org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver())
                 .build();
 
         user = createUser();
-
-        // Configure mockito to be more lenient with argument matching
-//        lenient().when(certificateService.create(any(String.class), any(CertificateRequestDTO.class)))
-//                .thenReturn(createMockResponseDTO());
     }
 
     private User createUser() {

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
@@ -20,7 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/CertificateControllerTest.java
@@ -1,12 +1,17 @@
 package rencanakan.id.talentpool.unit.controller;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -15,107 +20,242 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import rencanakan.id.talentpool.controller.CertificateController;
+import rencanakan.id.talentpool.dto.CertificateRequestDTO;
 import rencanakan.id.talentpool.dto.CertificateResponseDTO;
+import rencanakan.id.talentpool.model.User;
 import rencanakan.id.talentpool.service.CertificateService;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class CertificateControllerTest {
-    
+
+    // Add Mockito rule to allow lenient stubbing
+//    @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+
     @Mock
     private CertificateService certificateService;
-    
+
     @InjectMocks
     private CertificateController certificateController;
-    
+
     private MockMvc mockMvc;
-    
+
+    private ObjectMapper objectMapper;
+
+    private User user;
+
     @BeforeEach
     void setUp() {
+        objectMapper = Jackson2ObjectMapperBuilder.json()
+                .modules(new JavaTimeModule())
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+
         mockMvc = MockMvcBuilders
                 .standaloneSetup(certificateController)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+//                .setControllerAdvice(new org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver())
+                .build();
+
+        user = createUser();
+
+        // Configure mockito to be more lenient with argument matching
+//        lenient().when(certificateService.create(any(String.class), any(CertificateRequestDTO.class)))
+//                .thenReturn(createMockResponseDTO());
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id("talent-123")
+                .firstName("John")
+                .lastName("Doe")
+                .email("john.doe@example.com")
                 .build();
     }
-    
+
+    private CertificateRequestDTO createValidRequestDTO() {
+        return CertificateRequestDTO.builder()
+                .title("Java Certificate")
+                .file("certificate.pdf")
+                .build();
+    }
+
+    private CertificateResponseDTO createMockResponseDTO() {
+        return CertificateResponseDTO.builder()
+                .id(1L)
+                .title("Java Certificate")
+                .file("certificate.pdf")
+                .talentId("talent-123")
+                .build();
+    }
+
+    @Nested
+    class CreateCertificateTests {
+        @Test
+        void createCertificate_Success() throws Exception {
+            // Arrange
+            CertificateRequestDTO request = createValidRequestDTO();
+            CertificateResponseDTO mockResponse = createMockResponseDTO();
+
+            // Use any() for more flexible argument matching
+            when(certificateService.create(any(), any(CertificateRequestDTO.class)))
+                    .thenReturn(mockResponse);
+
+            // Act & Assert
+            mockMvc.perform(post("/certificates")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(SecurityMockMvcRequestPostProcessors.user(user))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.title").value("Java Certificate"))
+                    .andExpect(jsonPath("$.data.file").value("certificate.pdf"))
+                    .andExpect(jsonPath("$.data.talentId").value("talent-123"));
+
+            // Verify service was called (without strict argument matching)
+            verify(certificateService, times(1))
+                    .create(any(), any(CertificateRequestDTO.class));
+        }
+
+        @Test
+        void createCertificate_InvalidRequest_ShouldReturnBadRequest() throws Exception {
+            // Arrange
+            CertificateRequestDTO invalidRequest = new CertificateRequestDTO(); // Empty request
+
+            // Act & Assert
+            mockMvc.perform(post("/certificates")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(SecurityMockMvcRequestPostProcessors.user(user))
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(result -> assertThat(result.getResolvedException(), instanceOf(MethodArgumentNotValidException.class)));
+
+            verify(certificateService, never()).create(any(), any());
+        }
+
+        @Test
+        void createCertificate_WithMissingTitle_ShouldReturnBadRequest() throws Exception {
+            // Arrange
+            CertificateRequestDTO invalidRequest = CertificateRequestDTO.builder()
+                    .file("certificate.pdf")
+                    .build(); // Missing title
+
+            // Act & Assert
+            mockMvc.perform(post("/certificates")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(SecurityMockMvcRequestPostProcessors.user(user))
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+
+            verify(certificateService, never()).create(any(), any());
+        }
+
+        @Test
+        void createCertificate_WithMissingFile_ShouldReturnBadRequest() throws Exception {
+            // Arrange
+            CertificateRequestDTO invalidRequest = CertificateRequestDTO.builder()
+                    .title("Java Certificate")
+                    .build(); // Missing file
+
+            // Act & Assert
+            mockMvc.perform(post("/certificates")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(SecurityMockMvcRequestPostProcessors.user(user))
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+
+            verify(certificateService, never()).create(any(), any());
+        }
+    }
+
     @Nested
     class ReadCertificateTests {
-        
+
         private String token;
         private String talentId;
         private Long certificateId;
         private List<CertificateResponseDTO> certificateList;
         private CertificateResponseDTO certificate;
-        
+
         @BeforeEach
         void setUp() {
             token = "Bearer token";
             talentId = "talent-123";
             certificateId = 1L;
-            
+
             certificate = new CertificateResponseDTO();
             certificate.setId(certificateId);
             certificate.setTitle("Java Certificate");
             certificate.setFile("certificate.pdf");
             certificate.setTalentId(talentId);
-            
+
             certificateList = new ArrayList<>();
             certificateList.add(certificate);
         }
-        
+
         @Test
         void getCertificatesByUserId_ShouldReturnCertificates() throws Exception {
             when(certificateService.getByUserId(talentId)).thenReturn(certificateList);
-            
+
             mockMvc.perform(get("/certificates/user/{userId}", talentId)
-                    .header("Authorization", token))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data", hasSize(1)))
-                .andExpect(jsonPath("$.data[0].id").value(certificateId))
-                .andExpect(jsonPath("$.data[0].title").value("Java Certificate"))
-                .andExpect(jsonPath("$.data[0].file").value("certificate.pdf"));
-            
+                            .header("Authorization", token))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data", hasSize(1)))
+                    .andExpect(jsonPath("$.data[0].id").value(certificateId))
+                    .andExpect(jsonPath("$.data[0].title").value("Java Certificate"))
+                    .andExpect(jsonPath("$.data[0].file").value("certificate.pdf"));
+
             verify(certificateService, times(1)).getByUserId(talentId);
         }
-        
+
         @Test
         void getCertificatesByUserId_WhenNoCertificates_ShouldReturnEmptyList() throws Exception {
             List<CertificateResponseDTO> emptyList = new ArrayList<>();
             when(certificateService.getByUserId(talentId)).thenReturn(emptyList);
-            
+
             mockMvc.perform(get("/certificates/user/{userId}", talentId)
-                    .header("Authorization", token))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data", hasSize(0)));
-            
+                            .header("Authorization", token))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data", hasSize(0)));
+
             verify(certificateService, times(1)).getByUserId(talentId);
         }
-        
+
         @Test
         void getCertificateById_ShouldReturnCertificate() throws Exception {
             when(certificateService.getById(certificateId)).thenReturn(certificate);
-            
+
             mockMvc.perform(get("/certificates/{id}", certificateId)
-                    .header("Authorization", token))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(certificateId))
-                .andExpect(jsonPath("$.data.title").value("Java Certificate"))
-                .andExpect(jsonPath("$.data.file").value("certificate.pdf"));
-            
+                            .header("Authorization", token))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(certificateId))
+                    .andExpect(jsonPath("$.data.title").value("Java Certificate"))
+                    .andExpect(jsonPath("$.data.file").value("certificate.pdf"));
+
             verify(certificateService, times(1)).getById(certificateId);
         }
-        
+
         @Test
         void getCertificateById_WhenNotFound_ShouldReturnNotFound() throws Exception {
             when(certificateService.getById(certificateId)).thenReturn(null);
-            
+
             mockMvc.perform(get("/certificates/{id}", certificateId)
-                    .header("Authorization", token))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").isEmpty());
-            
+                            .header("Authorization", token))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isEmpty());
+
             verify(certificateService, times(1)).getById(certificateId);
         }
     }

--- a/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/CertificateServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -169,6 +170,213 @@ class CertificateServiceTest {
             }
             
             verify(certificateRepository).findById(1L);
+        }
+    }
+
+    @Nested
+    class CreateCertificateTests {
+        private User user;
+        private String userId;
+        private Certificate certificate;
+        private CertificateResponseDTO certificateRequestDTO;
+        private CertificateResponseDTO certificateResponseDTO;
+
+        @BeforeEach
+        void setUp() {
+            user = User.builder()
+                    .id("talent-123")
+                    .firstName("John")
+                    .lastName("Doe")
+                    .email("john.doe@example.com")
+                    .password("password123")
+                    .phoneNumber("1234567890")
+                    .photo("profile.jpg")
+                    .aboutMe("About me text")
+                    .nik("1234567890123456")
+                    .npwp("12.345.678.9-012.345")
+                    .photoKtp("ktp.jpg")
+                    .photoNpwp("npwp.jpg")
+                    .photoIjazah("ijazah.jpg")
+                    .experienceYears(5)
+                    .skkLevel("Intermediate")
+                    .currentLocation("Jakarta")
+                    .preferredLocations(Arrays.asList("Jakarta", "Bandung"))
+                    .skill("Java, Spring Boot")
+                    .build();
+
+            userId = user.getId();
+
+            certificateRequestDTO = new CertificateResponseDTO();
+            certificateRequestDTO.setTitle("Java Certificate");
+            certificateRequestDTO.setFile("java-cert.pdf");
+
+            certificate = Certificate.builder()
+                    .id(1L)
+                    .title("Java Certificate")
+                    .file("java-cert.pdf")
+                    .user(User.builder().id(userId).build())
+                    .build();
+
+            certificateResponseDTO = new CertificateResponseDTO();
+            certificateResponseDTO.setId(1L);
+            certificateResponseDTO.setTitle("Java Certificate");
+            certificateResponseDTO.setFile("java-cert.pdf");
+        }
+
+        @Test
+        void create_WithValidData_ShouldReturnSavedDTO() {
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                // Create a certificate without user set to verify the method sets it correctly
+                Certificate certificateWithoutUser = Certificate.builder()
+                        .title("Java Certificate")
+                        .file("java-cert.pdf")
+                        .build();
+
+                // Mock mapping from DTO to entity
+                dtoMapperMock.when(() -> DTOMapper.map(eq(certificateRequestDTO), eq(Certificate.class)))
+                        .thenReturn(certificateWithoutUser);
+
+                // Use argument captor to verify the saved entity has the user set
+                ArgumentCaptor<Certificate> certificateCaptor = ArgumentCaptor.forClass(Certificate.class);
+
+                // Mock the repository save
+                when(certificateRepository.save(certificateCaptor.capture())).thenReturn(certificate);
+
+                // Mock mapping from entity back to DTO
+                dtoMapperMock.when(() -> DTOMapper.map(eq(certificate), eq(CertificateResponseDTO.class)))
+                        .thenReturn(certificateResponseDTO);
+
+                // Execute the method
+                CertificateResponseDTO result = certificateService.create(userId, certificateRequestDTO);
+
+                // Verify the result
+                assertNotNull(result);
+                assertEquals(1L, result.getId());
+                assertEquals("Java Certificate", result.getTitle());
+                assertEquals("java-cert.pdf", result.getFile());
+
+                // Verify the user was set correctly
+                Certificate capturedCertificate = certificateCaptor.getValue();
+                assertNotNull(capturedCertificate.getUser());
+                assertEquals(userId, capturedCertificate.getUser().getId());
+
+                // Verify interactions
+                verify(certificateRepository).save(certificateCaptor.capture());
+            }
+        }
+
+        @Test
+        void create_WithNullUserId_ShouldThrowIllegalArgumentException() {
+            // Execute and verify exception
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> certificateService.create(null, certificateRequestDTO)
+            );
+
+            assertEquals("Certification request cannot be null", exception.getMessage());
+
+            // Verify no interactions with repository
+            verifyNoInteractions(certificateRepository);
+        }
+
+        @Test
+        void create_WithNullRequest_ShouldThrowIllegalArgumentException() {
+            // Execute and verify exception
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> certificateService.create(userId, null)
+            );
+
+            assertEquals("Certification request cannot be null", exception.getMessage());
+
+            // Verify no interactions with repository
+            verifyNoInteractions(certificateRepository);
+        }
+
+        @Test
+        void create_WhenMapperFails_ShouldPropagateException() {
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                // Mock mapping exception
+                dtoMapperMock.when(() -> DTOMapper.map(eq(certificateRequestDTO), eq(Certificate.class)))
+                        .thenThrow(RuntimeException.class);
+
+                // Execute and verify exception
+                assertThrows(
+                        RuntimeException.class,
+                        () -> certificateService.create(userId, certificateRequestDTO)
+                );
+
+                // Verify no interactions with repository
+                verifyNoInteractions(certificateRepository);
+            }
+        }
+
+        @Test
+        void create_WhenRepositorySaveFails_ShouldPropagateException() {
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                // Mock mapping from DTO to entity
+                dtoMapperMock.when(() -> DTOMapper.map(eq(certificateRequestDTO), eq(Certificate.class)))
+                        .thenReturn(certificate);
+
+                // Mock repository save to throw exception
+                when(certificateRepository.save(any(Certificate.class)))
+                        .thenThrow(new RuntimeException("Database error"));
+
+                // Execute and verify exception
+                RuntimeException exception = assertThrows(
+                        RuntimeException.class,
+                        () -> certificateService.create(userId, certificateRequestDTO)
+                );
+
+                assertEquals("Database error", exception.getMessage());
+
+                // Verify interactions
+                verify(certificateRepository).save(any(Certificate.class));
+            }
+        }
+
+        @Test
+        void create_WithEmptyTitle_ShouldProcessRequest() {
+            // Create certificate with empty title
+            CertificateResponseDTO emptyTitleRequest = new CertificateResponseDTO();
+            emptyTitleRequest.setTitle("");
+            emptyTitleRequest.setFile("java-cert.pdf");
+
+            Certificate emptyTitleCertificate = Certificate.builder()
+                    .id(1L)
+                    .title("")
+                    .file("java-cert.pdf")
+                    .user(User.builder().id(userId).build())
+                    .build();
+
+            CertificateResponseDTO emptyTitleResponse = new CertificateResponseDTO();
+            emptyTitleResponse.setId(1L);
+            emptyTitleResponse.setTitle("");
+            emptyTitleResponse.setFile("java-cert.pdf");
+
+            try (MockedStatic<DTOMapper> dtoMapperMock = mockStatic(DTOMapper.class)) {
+                // Mock mapping from DTO to entity
+                dtoMapperMock.when(() -> DTOMapper.map(eq(emptyTitleRequest), eq(Certificate.class)))
+                        .thenReturn(emptyTitleCertificate);
+
+                // Mock the repository save
+                when(certificateRepository.save(any(Certificate.class))).thenReturn(emptyTitleCertificate);
+
+                // Mock mapping from entity back to DTO
+                dtoMapperMock.when(() -> DTOMapper.map(eq(emptyTitleCertificate), eq(CertificateResponseDTO.class)))
+                        .thenReturn(emptyTitleResponse);
+
+                // Execute the method
+                CertificateResponseDTO result = certificateService.create(userId, emptyTitleRequest);
+
+                // Verify the result
+                assertNotNull(result);
+                assertEquals(1L, result.getId());
+                assertEquals("", result.getTitle());
+
+                // Verify interactions
+                verify(certificateRepository).save(any(Certificate.class));
+            }
         }
     }
 }


### PR DESCRIPTION
# Description  
make task create in backend for certificate without bucket handling

# Ticket Issue 
[Provide link to Jira](https://a-man-ppl.atlassian.net/browse/AMAN-39)  

# Changes Made  
[Describe your changes, it can be code snippets, screenshots, or plain sentences as needed]  

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [x] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [x] 🔍 Testing

# Added/updated tests?
<!--We encourage you to keep the code coverage percentage at 80% and above-->
- [x] Yes
- [ ] No, and this is why: [please replace this line with details on why tests have not been included]

# Additional Notes  
[Include any extra information or considerations for reviewers, such as impacted areas of the codebase]

# (optional) What photo/gif best describes this PR or how it makes you feel?
[For the sake of our sanity and some fun, let's make code reviews more entertaining! 😆🎉] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a certificate creation feature that enables users to submit certificate requests and receive confirmation of successful issuance.
  
- **Tests**
  - Enhanced automated tests ensure that certificate creation handles both valid submissions and various error scenarios effectively, including null inputs and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->