### PR TITLE
fix: remove dto validation for company image

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/dto/ExperienceRequestDTO.java
+++ b/src/main/java/rencanakan/id/talentpool/dto/ExperienceRequestDTO.java
@@ -23,7 +23,6 @@ public class ExperienceRequestDTO {
     @Size(max = 50, message = "Company must not exceed 50 characters")
     private String company;
 
-    @NotBlank(message = "Company image is required")
     private String companyImage;
 
     @NotNull(message = "Employment type is required")

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -16,6 +16,6 @@ security.jwt.secret-key=3cfa76ef14937c1c0ea519f8fc057a80fcd04a7420f8e8bcd0a7567c
 security.jwt.expiration-time=86400000
 
 management.endpoints.web.exposure.include=health,info,prometheus
-management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+#management.endpoint.prometheus.enabled=true
+#management.metrics.export.prometheus.enabled=true
 


### PR DESCRIPTION
# Description  
remove asset

# Ticket Issue 
-

# Changes Made  
[Describe your changes, it can be code snippets, screenshots, or plain sentences as needed]  

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [ ] 💻 New feature 
- [ ] 📄 Documentation update
- [X] ⚠️ Breaking changes
- [ ] 🔍 Testing

# Added/updated tests?
<!--We encourage you to keep the code coverage percentage at 80% and above-->
- [ ] Yes
- [ ] No, and this is why: [please replace this line with details on why tests have not been included]

# Additional Notes  
[Include any extra information or considerations for reviewers, such as impacted areas of the codebase]

# (optional) What photo/gif best describes this PR or how it makes you feel?
[For the sake of our sanity and some fun, let's make code reviews more entertaining! 😆🎉] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The company image field is no longer required when submitting experience information, allowing it to be left blank without causing validation errors.

- **Chores**
  - Disabled Prometheus metrics and endpoint in the development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->