### PR TITLE
Aman 148/reject recommendation

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -83,6 +83,18 @@ public class RecommendationController {
         }
     }
 
+    @PatchMapping("/{recommendationId}/reject")
+    public ResponseEntity<WebResponse<RecommendationResponseDTO>> rejectById(
+            @PathVariable("recommendationId") String recommendationId,
+            @AuthenticationPrincipal User user) {
+
+        RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.DECLINED);
+
+        return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                    .data(resp)
+                    .build());
+    }
+
     @GetMapping("/{recommendationId}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> getRecommendationById(
             @PathVariable("recommendationId") String recommendationId,

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -1,8 +1,10 @@
 package rencanakan.id.talentpool.controller;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,11 +59,28 @@ public class RecommendationController {
             @PathVariable("recommendationId") String recommendationId,
             @AuthenticationPrincipal User user) {
 
-        RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.ACCEPTED);
+        try {
+            RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.ACCEPTED);
 
-        return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
-                    .data(resp)
-                    .build());
+            return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                        .data(resp)
+                        .build());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        }
     }
 
     @GetMapping("/{recommendationId}")

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -88,11 +88,28 @@ public class RecommendationController {
             @PathVariable("recommendationId") String recommendationId,
             @AuthenticationPrincipal User user) {
 
-        RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.DECLINED);
+        try {
+            RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.DECLINED);
 
-        return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
-                    .data(resp)
-                    .build());
+            return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                        .data(resp)
+                        .build());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        }
     }
 
     @GetMapping("/{recommendationId}")

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -3,12 +3,9 @@ package rencanakan.id.talentpool.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-import rencanakan.id.talentpool.dto.RecommendationRequestDTO;import org.springframework.web.server.ResponseStatusException;
+
 import rencanakan.id.talentpool.model.User;
 import rencanakan.id.talentpool.dto.*;
 import rencanakan.id.talentpool.enums.StatusType;
@@ -42,8 +39,8 @@ public class RecommendationController {
                 .build();
 
         return ResponseEntity.ok(response);
-
     }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> deleteByStatusId(
             @PathVariable("id") String id,
@@ -53,9 +50,19 @@ public class RecommendationController {
                 .data(res)
                 .build();
         return ResponseEntity.ok(response);
-
     }
 
+    @PatchMapping("/{recommendationId}/accept")
+    public ResponseEntity<WebResponse<RecommendationResponseDTO>> acceptById(
+            @PathVariable("recommendationId") String recommendationId,
+            @AuthenticationPrincipal User user) {
+
+        RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.ACCEPTED);
+
+        return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                    .data(resp)
+                    .build());
+    }
 
     @GetMapping("/{recommendationId}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> getRecommendationById(
@@ -194,6 +201,5 @@ public class RecommendationController {
 
         RecommendationResponseDTO response = recommendationService.createRecommendation(user.getId(), request);
         return ResponseEntity.ok(response);
-        }
-
     }
+}

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -323,7 +323,7 @@ class RecommendationControllerTest {
 					recommendationId, "user-id-1", 123L, "contractorName", "Some message", StatusType.ACCEPTED
 			);
 			
-			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+			when(recommendationService.editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED))
 					.thenReturn(acceptedRecommendation);
 
 			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
@@ -333,14 +333,14 @@ class RecommendationControllerTest {
 					.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
 					.andExpect(jsonPath("$.errors").isEmpty());
 			
-			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+			verify(recommendationService).editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED);
 		}
 		
 		@Test
 		void testAcceptRecommendation_NotFound() throws Exception {
 			String nonExistingId = "non-existing-id";
 			
-			when(recommendationService.editStatusById(eq(testUser.getId()), eq(nonExistingId), eq(StatusType.ACCEPTED)))
+			when(recommendationService.editStatusById(testUser.getId(), nonExistingId, StatusType.ACCEPTED))
 					.thenThrow(new EntityNotFoundException("Recommendation with ID " + nonExistingId + " not found"));
 
 			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", nonExistingId)
@@ -348,14 +348,14 @@ class RecommendationControllerTest {
 					.andExpect(status().isNotFound())
 					.andExpect(jsonPath("$.errors").value("Recommendation with ID " + nonExistingId + " not found"));
 			
-			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(nonExistingId), eq(StatusType.ACCEPTED));
+			verify(recommendationService).editStatusById(testUser.getId(), nonExistingId, StatusType.ACCEPTED);
 		}
 		
 		@Test
 		void testAcceptRecommendation_Unauthorized() throws Exception {
 			String recommendationId = "rec-id-1";
 			
-			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+			when(recommendationService.editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED))
 					.thenThrow(new AccessDeniedException("You are not allowed to edit this recommendation."));
 
 			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
@@ -363,7 +363,7 @@ class RecommendationControllerTest {
 					.andExpect(status().isForbidden())
 					.andExpect(jsonPath("$.errors").value("You are not allowed to edit this recommendation."));
 			
-			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+			verify(recommendationService).editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED);
 		}
 		
 		@Test
@@ -373,7 +373,7 @@ class RecommendationControllerTest {
 					recommendationId, "user-id-1", 123L, "contractorName", "Already accepted message", StatusType.ACCEPTED
 			);
 			
-			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+			when(recommendationService.editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED))
 					.thenReturn(alreadyAcceptedRecommendation);
 
 			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
@@ -383,14 +383,14 @@ class RecommendationControllerTest {
 					.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
 					.andExpect(jsonPath("$.errors").isEmpty());
 			
-			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+			verify(recommendationService).editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED);
 		}
 		
 		@Test
 		void testAcceptRecommendation_ServerError() throws Exception {
 			String recommendationId = "error-id";
 			
-			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+			when(recommendationService.editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED))
 					.thenThrow(new RuntimeException("Unexpected server error"));
 
 			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
@@ -398,7 +398,7 @@ class RecommendationControllerTest {
 					.andExpect(status().isInternalServerError())
 					.andExpect(jsonPath("$.errors").value("Unexpected server error"));
 			
-			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+			verify(recommendationService).editStatusById(testUser.getId(), recommendationId, StatusType.ACCEPTED);
 		}
 	}
 

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -136,7 +136,7 @@ class RecommendationControllerTest {
                             .content(mapper.writeValueAsString(request)))
                     .andDo(print())
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.id").value("recommendation123")) // Change from $.data.id
+                    .andExpect(jsonPath("$.id").value("recommendation123"))
                     .andExpect(jsonPath("$.contractorId").value(1L))
                     .andExpect(jsonPath("$.contractorName").value("Contractor name"))
                     .andExpect(jsonPath("$.message").value("Test controller message"))
@@ -298,6 +298,109 @@ class RecommendationControllerTest {
         }
     }
 
+	@Nested
+	class AcceptRecommendationTests {
+		private User testUser;
+
+		@BeforeEach
+		void setUp() {
+			testUser = new User();
+			testUser.setId("user-id-1");
+			testUser.setEmail("john.doe@email.com");
+
+			mockMvc = MockMvcBuilders
+					.standaloneSetup(recommendationController)
+					.setCustomArgumentResolvers(new PrincipalDetailsArgumentResolver(testUser))
+					.setControllerAdvice(new ErrorController())
+					.setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+					.build();
+		}
+
+		@Test
+		void testAcceptRecommendation_Success() throws Exception {
+			String recommendationId = "rec-id-1";
+			RecommendationResponseDTO acceptedRecommendation = new RecommendationResponseDTO(
+					recommendationId, "user-id-1", 123L, "contractorName", "Some message", StatusType.ACCEPTED
+			);
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenReturn(acceptedRecommendation);
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.data.id").value(recommendationId))
+					.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+					.andExpect(jsonPath("$.errors").isEmpty());
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_NotFound() throws Exception {
+			String nonExistingId = "non-existing-id";
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(nonExistingId), eq(StatusType.ACCEPTED)))
+					.thenThrow(new EntityNotFoundException("Recommendation with ID " + nonExistingId + " not found"));
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", nonExistingId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.errors").value("Recommendation with ID " + nonExistingId + " not found"));
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(nonExistingId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_Unauthorized() throws Exception {
+			String recommendationId = "rec-id-1";
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenThrow(new AccessDeniedException("You are not allowed to edit this recommendation."));
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.errors").value("You are not allowed to edit this recommendation."));
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_AlreadyAccepted() throws Exception {
+			String recommendationId = "already-accepted-id";
+			RecommendationResponseDTO alreadyAcceptedRecommendation = new RecommendationResponseDTO(
+					recommendationId, "user-id-1", 123L, "contractorName", "Already accepted message", StatusType.ACCEPTED
+			);
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenReturn(alreadyAcceptedRecommendation);
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.data.id").value(recommendationId))
+					.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+					.andExpect(jsonPath("$.errors").isEmpty());
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_ServerError() throws Exception {
+			String recommendationId = "error-id";
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenThrow(new RuntimeException("Unexpected server error"));
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isInternalServerError())
+					.andExpect(jsonPath("$.errors").value("Unexpected server error"));
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+	}
 
         @Nested
         class ReadRecommendationTests {
@@ -587,5 +690,5 @@ class RecommendationControllerTest {
 
 }
 
- 
+
 


### PR DESCRIPTION
# Description  
Added endpoint for rejecting recommendations via a dedicated /recommendations/{recommendationId}/reject endpoint with appropriate error handling.

# Ticket Issue 
https://a-man-ppl.atlassian.net/browse/AMAN-148

# Changes Made  
Added new @PatchMapping("/{recommendationId}/reject") endpoint that specifically handles recommendation rejection

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [X] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [ ] 🔍 Testing

# Added/updated tests?
- [X] Yes
- [ ] No

# Additional Notes  
100% Code Coverage

# (optional) What photo/gif best describes this PR or how it makes you feel?
![Test All The Things](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added endpoints for accepting or rejecting recommendations, allowing users to update the status directly.

- **Tests**
  - Introduced comprehensive tests for the new accept and reject recommendation endpoints, covering success and error scenarios.
  - Minor correction in an existing test for accurate response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->