### PR TITLE
Aman 149/edit recommendation

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -221,4 +221,36 @@ public class RecommendationController {
         RecommendationResponseDTO response = recommendationService.createRecommendation(user.getId(), request);
         return ResponseEntity.ok(response);
     }
+
+    @PutMapping("/{recommendationId}/contractor/{contractorId}")
+    public ResponseEntity<WebResponse<RecommendationResponseDTO>> editRecommendationById(
+            @PathVariable("recommendationId") String recommendationId,
+            @PathVariable("contractorId") Long contractorId,
+            @RequestBody @Valid RecommendationRequestDTO editRequest) {
+
+        try {
+            editRequest.setContractorId(contractorId);
+            
+            RecommendationResponseDTO resp = recommendationService.editById(contractorId.toString(), recommendationId, editRequest);
+
+            return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                    .data(resp)
+                    .build());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                            .errors(e.getMessage())
+                            .build());
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                            .errors(e.getMessage())
+                            .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                            .errors(e.getMessage())
+                            .build());
+        }
+    }
 }

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -1,8 +1,10 @@
 package rencanakan.id.talentpool.controller;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,11 +59,28 @@ public class RecommendationController {
             @PathVariable("recommendationId") String recommendationId,
             @AuthenticationPrincipal User user) {
 
-        RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.ACCEPTED);
+        try {
+            RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.ACCEPTED);
 
-        return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
-                    .data(resp)
-                    .build());
+            return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                        .data(resp)
+                        .build());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                        .errors(e.getMessage())
+                        .build());
+        }
     }
 
     @GetMapping("/{recommendationId}")

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -229,7 +229,7 @@ public class RecommendationController {
             @RequestBody @Valid RecommendationRequestDTO editRequest) {
 
         try {
-            RecommendationResponseDTO resp = recommendationService.editById(contractorId.toString(), recommendationId, editRequest);
+            RecommendationResponseDTO resp = recommendationService.editById(contractorId, recommendationId, editRequest);
 
             return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
                     .data(resp)

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -229,8 +229,6 @@ public class RecommendationController {
             @RequestBody @Valid RecommendationRequestDTO editRequest) {
 
         try {
-            editRequest.setContractorId(contractorId);
-            
             RecommendationResponseDTO resp = recommendationService.editById(contractorId.toString(), recommendationId, editRequest);
 
             return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -3,12 +3,9 @@ package rencanakan.id.talentpool.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-import rencanakan.id.talentpool.dto.RecommendationRequestDTO;import org.springframework.web.server.ResponseStatusException;
+
 import rencanakan.id.talentpool.model.User;
 import rencanakan.id.talentpool.dto.*;
 import rencanakan.id.talentpool.enums.StatusType;
@@ -42,8 +39,8 @@ public class RecommendationController {
                 .build();
 
         return ResponseEntity.ok(response);
-
     }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> deleteByStatusId(
             @PathVariable("id") String id,
@@ -53,9 +50,19 @@ public class RecommendationController {
                 .data(res)
                 .build();
         return ResponseEntity.ok(response);
-
     }
 
+    @PatchMapping("/{recommendationId}/accept")
+    public ResponseEntity<WebResponse<RecommendationResponseDTO>> acceptById(
+            @PathVariable("recommendationId") String recommendationId,
+            @AuthenticationPrincipal User user) {
+
+        RecommendationResponseDTO resp = recommendationService.editStatusById(user.getId(), recommendationId, StatusType.ACCEPTED);
+
+        return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                    .data(resp)
+                    .build());
+    }
 
     @GetMapping("/{recommendationId}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> getRecommendationById(
@@ -194,6 +201,5 @@ public class RecommendationController {
 
         RecommendationResponseDTO response = recommendationService.createRecommendation(user.getId(), request);
         return ResponseEntity.ok(response);
-        }
-
     }
+}

--- a/src/main/java/rencanakan/id/talentpool/service/RecommendationService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/RecommendationService.java
@@ -11,7 +11,7 @@ public interface RecommendationService {
     RecommendationResponseDTO createRecommendation(String talentId, RecommendationRequestDTO recommendation);
     RecommendationResponseDTO deleteById(String userId,  String id);
     RecommendationResponseDTO editStatusById(String userId, String id, StatusType status);
-    RecommendationResponseDTO editById(String userId, String id, RecommendationRequestDTO request);
+    RecommendationResponseDTO editById(Long contractorId, String id, RecommendationRequestDTO request);
     RecommendationResponseDTO getById(String id);
     List<RecommendationResponseDTO> getByTalentId(String talentId);
     List<RecommendationResponseDTO> getByTalentIdAndStatus(String talentId, StatusType status);

--- a/src/main/java/rencanakan/id/talentpool/service/RecommendationService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/RecommendationService.java
@@ -11,6 +11,7 @@ public interface RecommendationService {
     RecommendationResponseDTO createRecommendation(String talentId, RecommendationRequestDTO recommendation);
     RecommendationResponseDTO deleteById(String userId,  String id);
     RecommendationResponseDTO editStatusById(String userId, String id, StatusType status);
+    RecommendationResponseDTO editById(String userId, String id, RecommendationRequestDTO request);
     RecommendationResponseDTO getById(String id);
     List<RecommendationResponseDTO> getByTalentId(String talentId);
     List<RecommendationResponseDTO> getByTalentIdAndStatus(String talentId, StatusType status);

--- a/src/main/java/rencanakan/id/talentpool/service/RecommendationServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/RecommendationServiceImpl.java
@@ -115,11 +115,11 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     @Override
-    public RecommendationResponseDTO editById(String contractorId, String id, RecommendationRequestDTO editRequest) {
+    public RecommendationResponseDTO editById(Long contractorId, String id, RecommendationRequestDTO editRequest) {
         Recommendation recommendation = recommendationRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Recommendation with ID " + id + " not found"));
 
-        if (!recommendation.getContractorId().equals(editRequest.getContractorId())) {
+        if (!recommendation.getContractorId().equals(contractorId)) {
             throw new AccessDeniedException("Only the contractor who created this recommendation can edit it");
         }
 
@@ -128,10 +128,9 @@ public class RecommendationServiceImpl implements RecommendationService {
         StatusType currentStatus = recommendation.getStatus();
         StatusType requestedStatus = editRequest.getStatus();
         
-        if ((currentStatus == StatusType.ACCEPTED || currentStatus == StatusType.DECLINED) 
-                && requestedStatus != currentStatus) {
+        if (currentStatus == StatusType.ACCEPTED || currentStatus == StatusType.DECLINED) {
             recommendation.setStatus(StatusType.PENDING);
-        } else {
+        } else if (requestedStatus != null) {
             recommendation.setStatus(requestedStatus);
         }
 

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -442,7 +442,7 @@ class RecommendationControllerTest {
 
 		@Test
 		void testEditRecommendation_Success() throws Exception {
-			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenReturn(editedRecommendation);
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -455,12 +455,12 @@ class RecommendationControllerTest {
 							.andExpect(jsonPath("$.data.status").value("PENDING"))
 							.andExpect(jsonPath("$.errors").isEmpty());
 			
-			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
 		void testEditRecommendation_RecommendationNotFound() throws Exception {
-			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenThrow(new EntityNotFoundException("Recommendation with ID " + recommendationId + " not found"));
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -469,12 +469,12 @@ class RecommendationControllerTest {
 							.andExpect(status().isNotFound())
 							.andExpect(jsonPath("$.errors").value("Recommendation with ID " + recommendationId + " not found"));
 			
-			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
 		void testEditRecommendation_Unauthorized() throws Exception {
-			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenThrow(new AccessDeniedException("Only the contractor who created this recommendation can edit it"));
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -483,7 +483,7 @@ class RecommendationControllerTest {
 							.andExpect(status().isForbidden())
 							.andExpect(jsonPath("$.errors").value("Only the contractor who created this recommendation can edit it"));
 			
-			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
@@ -512,7 +512,7 @@ class RecommendationControllerTest {
 							"Updated message only", StatusType.ACCEPTED // Status remains ACCEPTED
 			);
 			
-			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenReturn(responseWithStatusUnchanged);
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -524,12 +524,12 @@ class RecommendationControllerTest {
 							.andExpect(jsonPath("$.data.status").value("ACCEPTED")) // Status remains unchanged
 							.andExpect(jsonPath("$.errors").isEmpty());
 			
-			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
 		void testEditRecommendation_ServerError() throws Exception {
-			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenThrow(new RuntimeException("Unexpected server error"));
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -538,7 +538,7 @@ class RecommendationControllerTest {
 							.andExpect(status().isInternalServerError())
 							.andExpect(jsonPath("$.errors").value("Unexpected server error"));
 			
-			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
 		}
 	}
 

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -402,6 +402,146 @@ class RecommendationControllerTest {
 		}
 	}
 
+	@Nested
+	class EditRecommendationTests {
+		private RecommendationRequestDTO validEditRequest;
+		private String recommendationId;
+		private Long contractorId;
+		@SuppressWarnings("unused")
+		private RecommendationResponseDTO originalRecommendation;
+		private RecommendationResponseDTO editedRecommendation;
+
+		@BeforeEach
+		void setUp() {
+			mockMvc = MockMvcBuilders
+							.standaloneSetup(recommendationController)
+							.setControllerAdvice(new ErrorController())
+							.setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+							.build();
+
+			recommendationId = "rec-123";
+			contractorId = 123L;
+			
+			originalRecommendation = new RecommendationResponseDTO(
+							recommendationId, "talent-id", contractorId, "Contractor Name", 
+							"Original message", StatusType.ACCEPTED
+			);
+			
+			validEditRequest = RecommendationRequestDTO.builder()
+							.contractorId(contractorId)
+							.contractorName("Contractor Name")
+							.message("Updated recommendation message")
+							.status(StatusType.PENDING)
+							.build();
+			
+			editedRecommendation = new RecommendationResponseDTO(
+							recommendationId, "talent-id", contractorId, "Contractor Name", 
+							"Updated recommendation message", StatusType.PENDING
+			);
+		}
+
+		@Test
+		void testEditRecommendation_Success() throws Exception {
+			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+							.thenReturn(editedRecommendation);
+
+			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(validEditRequest)))
+							.andDo(print())
+							.andExpect(status().isOk())
+							.andExpect(jsonPath("$.data.id").value(recommendationId))
+							.andExpect(jsonPath("$.data.message").value("Updated recommendation message"))
+							.andExpect(jsonPath("$.data.status").value("PENDING"))
+							.andExpect(jsonPath("$.errors").isEmpty());
+			
+			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+		}
+		
+		@Test
+		void testEditRecommendation_RecommendationNotFound() throws Exception {
+			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+							.thenThrow(new EntityNotFoundException("Recommendation with ID " + recommendationId + " not found"));
+
+			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(validEditRequest)))
+							.andExpect(status().isNotFound())
+							.andExpect(jsonPath("$.errors").value("Recommendation with ID " + recommendationId + " not found"));
+			
+			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+		}
+		
+		@Test
+		void testEditRecommendation_Unauthorized() throws Exception {
+			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+							.thenThrow(new AccessDeniedException("Only the contractor who created this recommendation can edit it"));
+
+			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(validEditRequest)))
+							.andExpect(status().isForbidden())
+							.andExpect(jsonPath("$.errors").value("Only the contractor who created this recommendation can edit it"));
+			
+			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+		}
+		
+		@Test
+		void testEditRecommendation_InvalidRequest() throws Exception {
+			RecommendationRequestDTO invalidRequest = new RecommendationRequestDTO();
+			
+			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(invalidRequest)))
+							.andExpect(status().isBadRequest());
+			
+			verify(recommendationService, never()).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+		}
+		
+		@Test
+		void testEditRecommendation_KeepCurrentStatus() throws Exception {
+			RecommendationRequestDTO requestWithCurrentStatus = RecommendationRequestDTO.builder()
+							.contractorId(contractorId)
+							.contractorName("Contractor Name")
+							.message("Updated message only")
+							.status(StatusType.ACCEPTED) // Keeping the ACCEPTED status
+							.build();
+			
+			RecommendationResponseDTO responseWithStatusUnchanged = new RecommendationResponseDTO(
+							recommendationId, "talent-id", contractorId, "Contractor Name", 
+							"Updated message only", StatusType.ACCEPTED // Status remains ACCEPTED
+			);
+			
+			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+							.thenReturn(responseWithStatusUnchanged);
+
+			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(requestWithCurrentStatus)))
+							.andExpect(status().isOk())
+							.andExpect(jsonPath("$.data.id").value(recommendationId))
+							.andExpect(jsonPath("$.data.message").value("Updated message only"))
+							.andExpect(jsonPath("$.data.status").value("ACCEPTED")) // Status remains unchanged
+							.andExpect(jsonPath("$.errors").isEmpty());
+			
+			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+		}
+		
+		@Test
+		void testEditRecommendation_ServerError() throws Exception {
+			when(recommendationService.editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class)))
+							.thenThrow(new RuntimeException("Unexpected server error"));
+
+			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(validEditRequest)))
+							.andExpect(status().isInternalServerError())
+							.andExpect(jsonPath("$.errors").value("Unexpected server error"));
+			
+			verify(recommendationService).editById(eq(contractorId.toString()), eq(recommendationId), any(RecommendationRequestDTO.class));
+		}
+	}
+
         @Nested
         class ReadRecommendationTests {
             private User testUser;

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -136,7 +136,7 @@ class RecommendationControllerTest {
                             .content(mapper.writeValueAsString(request)))
                     .andDo(print())
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.id").value("recommendation123")) // Change from $.data.id
+                    .andExpect(jsonPath("$.id").value("recommendation123"))
                     .andExpect(jsonPath("$.contractorId").value(1L))
                     .andExpect(jsonPath("$.contractorName").value("Contractor name"))
                     .andExpect(jsonPath("$.message").value("Test controller message"))
@@ -298,6 +298,109 @@ class RecommendationControllerTest {
         }
     }
 
+	@Nested
+	class AcceptRecommendationTests {
+		private User testUser;
+
+		@BeforeEach
+		void setUp() {
+			testUser = new User();
+			testUser.setId("user-id-1");
+			testUser.setEmail("john.doe@email.com");
+
+			mockMvc = MockMvcBuilders
+					.standaloneSetup(recommendationController)
+					.setCustomArgumentResolvers(new PrincipalDetailsArgumentResolver(testUser))
+					.setControllerAdvice(new ErrorController())
+					.setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+					.build();
+		}
+
+		@Test
+		void testAcceptRecommendation_Success() throws Exception {
+			String recommendationId = "rec-id-1";
+			RecommendationResponseDTO acceptedRecommendation = new RecommendationResponseDTO(
+					recommendationId, "user-id-1", 123L, "contractorName", "Some message", StatusType.ACCEPTED
+			);
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenReturn(acceptedRecommendation);
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.data.id").value(recommendationId))
+					.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+					.andExpect(jsonPath("$.errors").isEmpty());
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_NotFound() throws Exception {
+			String nonExistingId = "non-existing-id";
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(nonExistingId), eq(StatusType.ACCEPTED)))
+					.thenThrow(new EntityNotFoundException("Recommendation with ID " + nonExistingId + " not found"));
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", nonExistingId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.errors").value("Recommendation with ID " + nonExistingId + " not found"));
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(nonExistingId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_Unauthorized() throws Exception {
+			String recommendationId = "rec-id-1";
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenThrow(new AccessDeniedException("You are not allowed to edit this recommendation."));
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.errors").value("You are not allowed to edit this recommendation."));
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_AlreadyAccepted() throws Exception {
+			String recommendationId = "already-accepted-id";
+			RecommendationResponseDTO alreadyAcceptedRecommendation = new RecommendationResponseDTO(
+					recommendationId, "user-id-1", 123L, "contractorName", "Already accepted message", StatusType.ACCEPTED
+			);
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenReturn(alreadyAcceptedRecommendation);
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.data.id").value(recommendationId))
+					.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+					.andExpect(jsonPath("$.errors").isEmpty());
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+		
+		@Test
+		void testAcceptRecommendation_ServerError() throws Exception {
+			String recommendationId = "error-id";
+			
+			when(recommendationService.editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED)))
+					.thenThrow(new RuntimeException("Unexpected server error"));
+
+			mockMvc.perform(patch("/recommendations/{recommendationId}/accept", recommendationId)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isInternalServerError())
+					.andExpect(jsonPath("$.errors").value("Unexpected server error"));
+			
+			verify(recommendationService).editStatusById(eq(testUser.getId()), eq(recommendationId), eq(StatusType.ACCEPTED));
+		}
+	}
 
         @Nested
         class ReadRecommendationTests {
@@ -587,5 +690,5 @@ class RecommendationControllerTest {
 
 }
 
- 
+
 

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -442,7 +442,7 @@ class RecommendationControllerTest {
 
 		@Test
 		void testEditRecommendation_Success() throws Exception {
-			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyLong(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenReturn(editedRecommendation);
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -455,12 +455,12 @@ class RecommendationControllerTest {
 							.andExpect(jsonPath("$.data.status").value("PENDING"))
 							.andExpect(jsonPath("$.errors").isEmpty());
 			
-			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyLong(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
 		void testEditRecommendation_RecommendationNotFound() throws Exception {
-			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyLong(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenThrow(new EntityNotFoundException("Recommendation with ID " + recommendationId + " not found"));
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -469,12 +469,12 @@ class RecommendationControllerTest {
 							.andExpect(status().isNotFound())
 							.andExpect(jsonPath("$.errors").value("Recommendation with ID " + recommendationId + " not found"));
 			
-			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyLong(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
 		void testEditRecommendation_Unauthorized() throws Exception {
-			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyLong(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenThrow(new AccessDeniedException("Only the contractor who created this recommendation can edit it"));
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -483,7 +483,7 @@ class RecommendationControllerTest {
 							.andExpect(status().isForbidden())
 							.andExpect(jsonPath("$.errors").value("Only the contractor who created this recommendation can edit it"));
 			
-			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyLong(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
@@ -495,7 +495,7 @@ class RecommendationControllerTest {
 							.content(objectMapper.writeValueAsString(invalidRequest)))
 							.andExpect(status().isBadRequest());
 			
-			verify(recommendationService, never()).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+			verify(recommendationService, never()).editById(any(), any(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
@@ -512,7 +512,7 @@ class RecommendationControllerTest {
 							"Updated message only", StatusType.ACCEPTED // Status remains ACCEPTED
 			);
 			
-			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyLong(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenReturn(responseWithStatusUnchanged);
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -524,12 +524,12 @@ class RecommendationControllerTest {
 							.andExpect(jsonPath("$.data.status").value("ACCEPTED")) // Status remains unchanged
 							.andExpect(jsonPath("$.errors").isEmpty());
 			
-			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyLong(), anyString(), any(RecommendationRequestDTO.class));
 		}
 		
 		@Test
 		void testEditRecommendation_ServerError() throws Exception {
-			when(recommendationService.editById(anyString(), anyString(), any(RecommendationRequestDTO.class)))
+			when(recommendationService.editById(anyLong(), anyString(), any(RecommendationRequestDTO.class)))
 							.thenThrow(new RuntimeException("Unexpected server error"));
 
 			mockMvc.perform(put("/recommendations/{recommendationId}/contractor/{contractorId}", recommendationId, contractorId)
@@ -538,7 +538,7 @@ class RecommendationControllerTest {
 							.andExpect(status().isInternalServerError())
 							.andExpect(jsonPath("$.errors").value("Unexpected server error"));
 			
-			verify(recommendationService).editById(anyString(), anyString(), any(RecommendationRequestDTO.class));
+			verify(recommendationService).editById(anyLong(), anyString(), any(RecommendationRequestDTO.class));
 		}
 	}
 

--- a/src/test/java/rencanakan/id/talentpool/unit/service/RecommendationServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/RecommendationServiceTest.java
@@ -588,6 +588,43 @@ class RecommendationServiceTest {
             verify(recommendationRepository).findById(recommendationId);
             verify(recommendationRepository).save(recommendation3);
         }
+        
+        @Test
+        void editById_KeepAcceptedStatus_WhenRequestingSameStatus() {
+            String userId = "contractor-id";
+            String recommendationId = "rec-id-2";
+            
+            // Original recommendation is ACCEPTED
+            recommendation2.setStatus(StatusType.ACCEPTED);
+            
+            RecommendationRequestDTO editRequest = new RecommendationRequestDTO();
+            editRequest.setContractorId(102L);
+            editRequest.setContractorName("Contractor B");
+            editRequest.setMessage("Updated message but keep status");
+            editRequest.setStatus(StatusType.ACCEPTED); // Same status as original
+            
+            when(recommendationRepository.findById(recommendationId)).thenReturn(Optional.of(recommendation2));
+            
+            Recommendation updatedRecommendation = new Recommendation();
+            updatedRecommendation.setId(recommendationId);
+            updatedRecommendation.setTalent(talent1);
+            updatedRecommendation.setContractorId(102L);
+            updatedRecommendation.setContractorName("Contractor B");
+            updatedRecommendation.setMessage("Updated message but keep status");
+            updatedRecommendation.setStatus(StatusType.ACCEPTED); // Should stay ACCEPTED
+            
+            when(recommendationRepository.save(any(Recommendation.class))).thenReturn(updatedRecommendation);
+            
+            RecommendationResponseDTO result = recommendationService.editById(userId, recommendationId, editRequest);
+            
+            assertNotNull(result);
+            assertEquals(recommendationId, result.getId());
+            assertEquals("Updated message but keep status", result.getMessage());
+            assertEquals(StatusType.ACCEPTED, result.getStatus()); // Status remains ACCEPTED
+            
+            verify(recommendationRepository).findById(recommendationId);
+            verify(recommendationRepository).save(recommendation2);
+        }
     }
 
     @Nested


### PR DESCRIPTION
# Description  
Added functionality for contractors to edit recommendations from an external system. Contractors can update recommendation messages and the system will reset the status to PENDING if it was previously ACCEPTED or DECLINED.

# Ticket Issue 
https://a-man-ppl.atlassian.net/browse/AMAN-149

# Changes Made  
Added new endpoint /recommendations/{recommendationId}/contractor/{contractorId} for external contractor access
Implemented editById method in service layer to handle recommendation edits
Added business logic to reset status to PENDING when recommendations are edited after acceptance/rejection
Added comprehensive test coverage for new functionality

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [X] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [ ] 🔍 Testing

# Added/updated tests?
- [X] Yes
- [ ] No

# Additional Notes  
100% Code Coverage

# (optional) What photo/gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to accept recommendations, updating their status to ACCEPTED.
  - Introduced an endpoint to edit recommendations by ID and contractor, allowing updates to details and status.

- **Bug Fixes**
  - Improved error handling for not found, unauthorized access, and server errors on new endpoints.

- **Tests**
  - Added comprehensive tests for accepting and editing recommendations, covering success and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->