### PR TITLE
Aman 142/email

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.assertj:assertj-core:3.24.2'
 
-
 	// Pact for Contract Testing
 	implementation 'au.com.dius.pact:consumer:4.6.17'
 	implementation 'au.com.dius.pact:provider:4.6.17'
@@ -76,6 +75,8 @@ dependencies {
 	//Prometheus
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	implementation("org.springframework.boot:spring-boot-starter-mail:3.4.5")
 
 }
 

--- a/src/main/java/rencanakan/id/talentpool/configs/SecurityConfiguration.java
+++ b/src/main/java/rencanakan/id/talentpool/configs/SecurityConfiguration.java
@@ -41,6 +41,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/users/contractor").permitAll()
+                        .requestMatchers("/api/email").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().denyAll()

--- a/src/main/java/rencanakan/id/talentpool/controller/EmailController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/EmailController.java
@@ -1,6 +1,5 @@
 package rencanakan.id.talentpool.controller;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import rencanakan.id.talentpool.service.EmailService;

--- a/src/main/java/rencanakan/id/talentpool/controller/EmailController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/EmailController.java
@@ -1,0 +1,25 @@
+package rencanakan.id.talentpool.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import rencanakan.id.talentpool.service.EmailService;
+
+@RestController
+@RequestMapping("/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    public EmailController(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @PostMapping
+    public ResponseEntity<String> sendResetPassword(@RequestBody ResetPasswordRequest request) {
+        emailService.processResetPassword(request.email());
+        return ResponseEntity.ok("Reset password email sent.");
+    }
+
+    public record ResetPasswordRequest(String email) {}
+}

--- a/src/main/java/rencanakan/id/talentpool/model/PasswordResetToken.java
+++ b/src/main/java/rencanakan/id/talentpool/model/PasswordResetToken.java
@@ -1,0 +1,23 @@
+package rencanakan.id.talentpool.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "password_reset_tokens")
+public class PasswordResetToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String token;
+    private LocalDateTime expiryDate;
+    private boolean used;
+}

--- a/src/main/java/rencanakan/id/talentpool/model/PasswordResetToken.java
+++ b/src/main/java/rencanakan/id/talentpool/model/PasswordResetToken.java
@@ -15,7 +15,6 @@ public class PasswordResetToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private String email;
     private String token;
     private LocalDateTime expiryDate;

--- a/src/main/java/rencanakan/id/talentpool/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/rencanakan/id/talentpool/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,11 @@
+package rencanakan.id.talentpool.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rencanakan.id.talentpool.model.PasswordResetToken;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+    Optional<PasswordResetToken> findByEmailAndUsedIsFalse(String email);
+}

--- a/src/main/java/rencanakan/id/talentpool/service/EmailService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/EmailService.java
@@ -1,0 +1,6 @@
+package rencanakan.id.talentpool.service;
+
+public interface EmailService {
+    void sendResetPasswordEmail(String to, String resetLink);
+    void processResetPassword(String email);
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -17,7 +17,16 @@ security.jwt.expiration-time=86400000
 
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+#management.metrics.export.prometheus.enabled=true
 #server.port = 8081
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=sunsetheusdev@gmail.com
+spring.mail.password=wexy kyap znpw xwix
+spring.mail.protocol=smtp
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.profiles.active=${PRODUCTION:dev}
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=sunsetheusdev@gmail.com
+spring.mail.password=wexy kyap znpw xwix
+spring.mail.protocol=smtp
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/EmailControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/EmailControllerTest.java
@@ -1,0 +1,63 @@
+package rencanakan.id.talentpool.unit.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import rencanakan.id.talentpool.controller.EmailController;
+import rencanakan.id.talentpool.service.EmailService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@ExtendWith(MockitoExtension.class)
+class EmailControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private EmailController emailController;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = Jackson2ObjectMapperBuilder.json()
+                .modules(new JavaTimeModule())
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+        mockMvc = MockMvcBuilders.standaloneSetup(emailController).build();
+    }
+
+    @Test
+    void postEmail_shouldCallEmailServiceAndReturn200() throws Exception {
+        // Arrange
+        String email = "test@example.com";
+        var requestBody = new EmailController.ResetPasswordRequest(email);
+
+        // Act & Assert
+        mockMvc.perform(post("/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestBody)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Reset password email sent."));
+
+        Mockito.verify(emailService).processResetPassword(email);
+    }
+}

--- a/src/test/java/rencanakan/id/talentpool/unit/model/PasswordResetTokenTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/model/PasswordResetTokenTest.java
@@ -1,0 +1,45 @@
+package rencanakan.id.talentpool.unit.model;
+
+import org.junit.jupiter.api.Test;
+import rencanakan.id.talentpool.model.PasswordResetToken;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PasswordResetTokenTest {
+
+    @Test
+    void itShouldCreatePasswordResetTokenWithBuilder() {
+        LocalDateTime now = LocalDateTime.now();
+        PasswordResetToken token = PasswordResetToken.builder()
+                .id(1L)
+                .email("user@example.com")
+                .token("abc123")
+                .expiryDate(now)
+                .used(false)
+                .build();
+
+        assertThat(token.getId()).isEqualTo(1L);
+        assertThat(token.getEmail()).isEqualTo("user@example.com");
+        assertThat(token.getToken()).isEqualTo("abc123");
+        assertThat(token.getExpiryDate()).isEqualTo(now);
+        assertThat(token.isUsed()).isFalse();
+    }
+
+    @Test
+    void itShouldAllowSettersAndGetters() {
+        PasswordResetToken token = new PasswordResetToken();
+        token.setId(2L);
+        token.setEmail("test@example.com");
+        token.setToken("xyz789");
+        token.setExpiryDate(LocalDateTime.of(2025, 5, 12, 10, 0));
+        token.setUsed(true);
+
+        assertThat(token.getId()).isEqualTo(2L);
+        assertThat(token.getEmail()).isEqualTo("test@example.com");
+        assertThat(token.getToken()).isEqualTo("xyz789");
+        assertThat(token.getExpiryDate()).isEqualTo(LocalDateTime.of(2025, 5, 12, 10, 0));
+        assertThat(token.isUsed()).isTrue();
+    }
+}

--- a/src/test/java/rencanakan/id/talentpool/unit/model/PasswordResetTokenTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/model/PasswordResetTokenTest.java
@@ -4,13 +4,12 @@ import org.junit.jupiter.api.Test;
 import rencanakan.id.talentpool.model.PasswordResetToken;
 
 import java.time.LocalDateTime;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PasswordResetTokenTest {
 
     @Test
-    void itShouldCreatePasswordResetTokenWithBuilder() {
+    void builder_shouldCreateTokenCorrectly() {
         LocalDateTime now = LocalDateTime.now();
         PasswordResetToken token = PasswordResetToken.builder()
                 .id(1L)
@@ -28,7 +27,7 @@ class PasswordResetTokenTest {
     }
 
     @Test
-    void itShouldAllowSettersAndGetters() {
+    void setters_shouldUpdateFieldsCorrectly() {
         PasswordResetToken token = new PasswordResetToken();
         token.setId(2L);
         token.setEmail("test@example.com");

--- a/src/test/java/rencanakan/id/talentpool/unit/service/EmailServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/EmailServiceTest.java
@@ -1,8 +1,9 @@
 package rencanakan.id.talentpool.unit.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import rencanakan.id.talentpool.model.PasswordResetToken;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class EmailServiceTest {
 
     @Mock
@@ -30,11 +32,6 @@ class EmailServiceTest {
 
     @Captor
     private ArgumentCaptor<SimpleMailMessage> mailCaptor;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     void itShouldGenerateAndSaveTokenAndSendEmail() {

--- a/src/test/java/rencanakan/id/talentpool/unit/service/EmailServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/EmailServiceTest.java
@@ -1,0 +1,64 @@
+package rencanakan.id.talentpool.unit.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import rencanakan.id.talentpool.model.PasswordResetToken;
+import rencanakan.id.talentpool.repository.PasswordResetTokenRepository;
+import rencanakan.id.talentpool.service.EmailServiceImpl;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class EmailServiceTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private PasswordResetTokenRepository tokenRepository;
+
+    @InjectMocks
+    private EmailServiceImpl emailService;
+
+    @Captor
+    private ArgumentCaptor<PasswordResetToken> tokenCaptor;
+
+    @Captor
+    private ArgumentCaptor<SimpleMailMessage> mailCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void itShouldGenerateAndSaveTokenAndSendEmail() {
+        // Given
+        String email = "user@example.com";
+
+        // When
+        emailService.processResetPassword(email);
+
+        // Then
+        verify(tokenRepository, times(1)).save(tokenCaptor.capture());
+        PasswordResetToken savedToken = tokenCaptor.getValue();
+
+        assertThat(savedToken.getEmail()).isEqualTo(email);
+        assertThat(savedToken.getToken()).isNotBlank();
+        assertThat(savedToken.getExpiryDate()).isAfter(LocalDateTime.now());
+        assertThat(savedToken.isUsed()).isFalse();
+
+        verify(mailSender, times(1)).send(mailCaptor.capture());
+        SimpleMailMessage message = mailCaptor.getValue();
+
+        assertThat(message.getTo()).containsExactly(email);
+        assertThat(message.getSubject()).contains("Reset Password");
+        assertThat(message.getText()).contains("Klik link berikut");
+        assertThat(message.getText()).contains(savedToken.getToken());
+    }
+}


### PR DESCRIPTION
# Description  
User now can get email to reset their password

# Ticket Issue 
https://a-man-ppl.atlassian.net/browse/AMAN-142?atlOrigin=eyJpIjoiZGMwOGQ0MWQwYmU3NGZmMTgyZGMyMjdmNGVkYjQ0ZDIiLCJwIjoiaiJ9

# Changes Made  
add smtp to send email that contains reset pw token to fe

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [X] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [ ] 🔍 Testing

# Added/updated tests?
<!--We encourage you to keep the code coverage percentage at 80% and above-->
- [X] Yes
- [ ] No, and this is why: [please replace this line with details on why tests have not been included]

# Additional Notes  
[Include any extra information or considerations for reviewers, such as impacted areas of the codebase]

# (optional) What photo/gif best describes this PR or how it makes you feel?
[For the sake of our sanity and some fun, let's make code reviews more entertaining! 😆🎉] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced password reset functionality, allowing users to request a password reset email with a secure link.
  - Added a public API endpoint to initiate password reset requests.
  - Integrated email sending capabilities using SMTP configuration.

- **Bug Fixes**
  - Adjusted security settings to allow unauthenticated access to the password reset endpoint.

- **Chores**
  - Updated project dependencies and configuration files for email support.

- **Tests**
  - Added unit tests for the password reset token model, email controller, and email service to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->