### PR TITLE
Aman 146/change create recommendation

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -1,20 +1,15 @@
 package rencanakan.id.talentpool.controller;
 
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-import rencanakan.id.talentpool.dto.RecommendationRequestDTO;import org.springframework.web.server.ResponseStatusException;
+import rencanakan.id.talentpool.dto.RecommendationRequestDTO;
 import rencanakan.id.talentpool.model.User;
 import rencanakan.id.talentpool.dto.*;
 import rencanakan.id.talentpool.enums.StatusType;
 import rencanakan.id.talentpool.service.RecommendationService;
-import rencanakan.id.talentpool.service.UserService;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -1,5 +1,6 @@
 package rencanakan.id.talentpool.controller;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import rencanakan.id.talentpool.model.User;
 import rencanakan.id.talentpool.dto.*;
 import rencanakan.id.talentpool.enums.StatusType;
 import rencanakan.id.talentpool.service.RecommendationService;
+import rencanakan.id.talentpool.service.UserService;
 
 import java.util.List;
 import java.util.Map;
@@ -183,17 +185,21 @@ public class RecommendationController {
         }
     }
 
-    @PostMapping
-    public ResponseEntity<RecommendationResponseDTO> createRecommendation(
-            @RequestBody @Valid RecommendationRequestDTO request,
-            @AuthenticationPrincipal User user) {
+    @PostMapping("/contractor/{talentId}")
+    public ResponseEntity<WebResponse<RecommendationResponseDTO>> createRecommendation(
+            @PathVariable("talentId") String talentId,
+            @RequestBody @Valid RecommendationRequestDTO request) {
 
-        if (user == null) {
-            return ResponseEntity.badRequest().build();
+        try {
+            RecommendationResponseDTO response = recommendationService.createRecommendation(talentId, request);
+            return ResponseEntity.ok(WebResponse.<RecommendationResponseDTO>builder()
+                    .data(response)
+                    .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    WebResponse.<RecommendationResponseDTO>builder()
+                            .errors(e.getMessage())
+                            .build());
         }
-
-        RecommendationResponseDTO response = recommendationService.createRecommendation(user.getId(), request);
-        return ResponseEntity.ok(response);
-        }
-
     }
+}

--- a/src/main/java/rencanakan/id/talentpool/service/RecommendationServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/RecommendationServiceImpl.java
@@ -106,11 +106,12 @@ public class RecommendationServiceImpl implements RecommendationService {
             throw new IllegalArgumentException("Recommendation request cannot be null");
         }
 
+        User talent = userRepository.findById(talentId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + talentId));
+
         Recommendation newRecommendation = DTOMapper.map(recommendation, Recommendation.class);
-        newRecommendation.setTalent(User.builder().id(talentId).build());
-
+        newRecommendation.setTalent(talent);
         Recommendation savedRecommendation = recommendationRepository.save(newRecommendation);
-
         return DTOMapper.map(savedRecommendation, RecommendationResponseDTO.class);
     }
 }


### PR DESCRIPTION
# Description  
Branch is a bit poorly named as my first adjustments are to change the logic of create recommendation so contractors can access the endpoint.

# Ticket Issue 
https://a-man-ppl.atlassian.net/browse/AMAN-146

# Changes Made  
Remove AuthPrincipal from create recommendation endpoint so contractors can access it, as well as adjust the service to accommodate that (previously, talent user was retrieved from authprincipal so we know it exists if it enters the service layer, but now its existence must be checked for in the service layer).

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [X] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [ ] 🔍 Testing

# Added/updated tests?
<!--We encourage you to keep the code coverage percentage at 80% and above-->
- [X] Yes
- [ ] No

# Additional Notes  


# (optional) What photo/gif best describes this PR or how it makes you feel?
Oughh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The endpoint for creating contractor recommendations now allows specifying the target talent by their ID in the URL.

- **Bug Fixes**
  - Improved error handling for cases where the specified talent is not found, returning a clear error message.

- **Tests**
  - Enhanced and clarified test coverage for recommendation creation, including new tests for user-not-found scenarios and improved assertion accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->