### PR TITLE
Aman 151/split hapus recom

### DIFF
--- a/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
+++ b/src/main/java/rencanakan/id/talentpool/controller/RecommendationController.java
@@ -44,18 +44,28 @@ public class RecommendationController {
         return ResponseEntity.ok(response);
 
     }
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{recommendationId}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> deleteByStatusId(
-            @PathVariable("id") String id,
+            @PathVariable("recommendationId") String recommendationId,
             @AuthenticationPrincipal User user ){
-        RecommendationResponseDTO res = this.recommendationService.deleteById(user.getId(),  id);
+        RecommendationResponseDTO res = this.recommendationService.deleteByIdTalent(user.getId(),  recommendationId);
         WebResponse<RecommendationResponseDTO> response = WebResponse.<RecommendationResponseDTO>builder()
                 .data(res)
                 .build();
         return ResponseEntity.ok(response);
-
     }
 
+    @DeleteMapping("/{recommendationId}/contractor/{contractorId}")
+    public ResponseEntity<WebResponse<RecommendationResponseDTO>> deleteByStatusId(
+            @PathVariable("recommendationId") String recommendationId,
+            @PathVariable("contractorId") Long contractorId){
+        RecommendationResponseDTO res = this.recommendationService
+                .deleteByIdContractor(contractorId, recommendationId);
+        WebResponse<RecommendationResponseDTO> response = WebResponse.<RecommendationResponseDTO>builder()
+                .data(res)
+                .build();
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/{recommendationId}")
     public ResponseEntity<WebResponse<RecommendationResponseDTO>> getRecommendationById(
@@ -194,6 +204,5 @@ public class RecommendationController {
 
         RecommendationResponseDTO response = recommendationService.createRecommendation(user.getId(), request);
         return ResponseEntity.ok(response);
-        }
-
     }
+}

--- a/src/main/java/rencanakan/id/talentpool/service/RecommendationService.java
+++ b/src/main/java/rencanakan/id/talentpool/service/RecommendationService.java
@@ -9,7 +9,8 @@ import java.util.Map;
     
 public interface RecommendationService {
     RecommendationResponseDTO createRecommendation(String talentId, RecommendationRequestDTO recommendation);
-    RecommendationResponseDTO deleteById(String userId,  String id);
+    RecommendationResponseDTO deleteByIdTalent(String userId,  String id);
+    RecommendationResponseDTO deleteByIdContractor(Long contractorId,  String id);
     RecommendationResponseDTO editStatusById(String userId, String id, StatusType status);
     RecommendationResponseDTO getById(String id);
     List<RecommendationResponseDTO> getByTalentId(String talentId);

--- a/src/main/java/rencanakan/id/talentpool/service/RecommendationServiceImpl.java
+++ b/src/main/java/rencanakan/id/talentpool/service/RecommendationServiceImpl.java
@@ -53,10 +53,22 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     @Override
-    public RecommendationResponseDTO deleteById(String userId, String id) {
+    public RecommendationResponseDTO deleteByIdTalent(String userId, String id) {
         Recommendation recommendation = recommendationRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Recommendation with id " + id + " not found."));
         if (!(recommendation.getTalent().getId().equals(userId))) {
+            throw new AccessDeniedException("You are not allowed to delete this recommendation.");
+        }
+        recommendationRepository.deleteById(id);
+        return  DTOMapper.map(recommendation, RecommendationResponseDTO.class);
+
+    }
+
+    @Override
+    public RecommendationResponseDTO deleteByIdContractor(Long contractorId, String id) {
+        Recommendation recommendation = recommendationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Recommendation with id " + id + " not found."));
+        if (!(recommendation.getContractorId().equals(contractorId))) {
             throw new AccessDeniedException("You are not allowed to delete this recommendation.");
         }
         recommendationRepository.deleteById(id);

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -256,50 +256,87 @@ class RecommendationControllerTest {
     }
 
     @Nested
-    class DeleteRecommendationTests{
-        @Test
-        void deleteByStatusId_NotFound_ShouldReturn404() throws Exception {
-            String notFoundId = "999";
-            doThrow(new EntityNotFoundException("Recommendation with id " + notFoundId + " not found."))
-                    .when(recommendationService).deleteById(any(), any());
+    class DeleteRecommendationTests {
+        @Nested
+        class DeleteByTalentTests {
 
-            mockMvc.perform(delete("/recommendations/{id}", notFoundId)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.errors").value("Recommendation with id " + notFoundId + " not found."));
+            @Test
+            void deleteByTalent_NotFound_ShouldReturn404() throws Exception {
+                String notFoundId = "999";
+                doThrow(new EntityNotFoundException("Recommendation with id " + notFoundId + " not found."))
+                        .when(recommendationService).deleteByIdTalent(any(), any());
 
+                mockMvc.perform(delete("/recommendations/{id}", notFoundId)
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.errors").value("Recommendation with id " + notFoundId + " not found."));
+            }
+
+            @Test
+            public void deleteByTalent_UserNotAuthorized_ShouldReturn403() throws Exception {
+                when(recommendationService.deleteByIdTalent(any(), eq(id)))
+                        .thenThrow(new AccessDeniedException("You are not allowed to delete this recommendation."));
+
+                mockMvc.perform(delete("/recommendations/{id}", id)
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.errors").value("You are not allowed to delete this recommendation."));
+            }
+
+            @Test
+            void deleteByTalent_Success_ShouldReturn200() throws Exception {
+                when(recommendationService.deleteByIdTalent(any(), eq(id))).thenReturn(responseDTO);
+
+                mockMvc.perform(delete("/recommendations/{id}", id)
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.id").value(id))
+                        .andExpect(jsonPath("$.data.talentId").value("talentId"))
+                        .andExpect(jsonPath("$.data.contractorId").value(123L))
+                        .andExpect(jsonPath("$.data.contractorName").value("contractorName"))
+                        .andExpect(jsonPath("$.data.message").value("Some message"))
+                        .andExpect(jsonPath("$.data.status").value("ACCEPTED"));
+            }
         }
 
-        @Test
-        public void testDelete_UserNotAuthorized_ReturnsForbidden() throws Exception {
+        @Nested
+        class DeleteByContractorTests {
 
-            when(recommendationService.deleteById(any(), eq(id)))
-                    .thenThrow(new AccessDeniedException("You are not allowed to delete this recommendation."));
+            @Test
+            void deleteByContractor_NotFound_ShouldReturn404() throws Exception {
+                String notFoundId = "999";
+                Long contractorId = 999L;
 
-            mockMvc.perform(delete("/recommendations/{id}", id)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(StatusType.ACCEPTED)))
-                    .andExpect(status().isForbidden()) // Expect 403 Forbidden status
-                    .andExpect(jsonPath("$.errors").value("You are not allowed to delete this recommendation.")); // Check error message
-        }
-        @Test
-        void deleteByStatusId_Success_ShouldReturn200() throws Exception {
-            when(recommendationService.deleteById(any(), eq(id))).thenReturn(responseDTO);
-            mockMvc.perform(delete("/recommendations/{id}", id)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk()) // Harus 200 OK
-                    .andExpect(jsonPath("$.data.id").value(id))
-                    .andExpect(jsonPath("$.data.talentId").value("talentId"))
-                    .andExpect(jsonPath("$.data.contractorId").value(123L))
-                    .andExpect(jsonPath("$.data.contractorName").value("contractorName"))
-                    .andExpect(jsonPath("$.data.message").value("Some message"))
-                    .andExpect(jsonPath("$.data.status").value("ACCEPTED"));
+                doThrow(new EntityNotFoundException("Recommendation with id " + notFoundId + " not found."))
+                        .when(recommendationService).deleteByIdContractor(eq(contractorId), eq(notFoundId));
 
+                mockMvc.perform(delete("/recommendations/{recommendationId}/contractor/{contractorId}", notFoundId, contractorId)
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.errors").value("Recommendation with id " + notFoundId + " not found."));
+            }
+
+            @Test
+            void deleteByContractor_Success_ShouldReturn200() throws Exception {
+                Long contractorId = 123L;
+
+                when(recommendationService.deleteByIdContractor(eq(contractorId), eq(id))).thenReturn(responseDTO);
+
+                mockMvc.perform(delete("/recommendations/{recommendationId}/contractor/{contractorId}", id, contractorId)
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.id").value(id))
+                        .andExpect(jsonPath("$.data.talentId").value("talentId"))
+                        .andExpect(jsonPath("$.data.contractorId").value(123L))
+                        .andExpect(jsonPath("$.data.contractorName").value("contractorName"))
+                        .andExpect(jsonPath("$.data.message").value("Some message"))
+                        .andExpect(jsonPath("$.data.status").value("ACCEPTED"));
+            }
         }
     }
 
 
-        @Nested
+    @Nested
         class ReadRecommendationTests {
             private User testUser;
             private RecommendationResponseDTO recommendation1;

--- a/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/controller/RecommendationControllerTest.java
@@ -273,7 +273,7 @@ class RecommendationControllerTest {
             }
 
             @Test
-            public void deleteByTalent_UserNotAuthorized_ShouldReturn403() throws Exception {
+            void deleteByTalent_UserNotAuthorized_ShouldReturn403() throws Exception {
                 when(recommendationService.deleteByIdTalent(any(), eq(id)))
                         .thenThrow(new AccessDeniedException("You are not allowed to delete this recommendation."));
 
@@ -308,7 +308,7 @@ class RecommendationControllerTest {
                 Long contractorId = 999L;
 
                 doThrow(new EntityNotFoundException("Recommendation with id " + notFoundId + " not found."))
-                        .when(recommendationService).deleteByIdContractor(eq(contractorId), eq(notFoundId));
+                        .when(recommendationService).deleteByIdContractor(contractorId, notFoundId);
 
                 mockMvc.perform(delete("/recommendations/{recommendationId}/contractor/{contractorId}", notFoundId, contractorId)
                                 .contentType(MediaType.APPLICATION_JSON))
@@ -320,7 +320,7 @@ class RecommendationControllerTest {
             void deleteByContractor_Success_ShouldReturn200() throws Exception {
                 Long contractorId = 123L;
 
-                when(recommendationService.deleteByIdContractor(eq(contractorId), eq(id))).thenReturn(responseDTO);
+                when(recommendationService.deleteByIdContractor(contractorId, id)).thenReturn(responseDTO);
 
                 mockMvc.perform(delete("/recommendations/{recommendationId}/contractor/{contractorId}", id, contractorId)
                                 .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/rencanakan/id/talentpool/unit/service/RecommendationServiceTest.java
+++ b/src/test/java/rencanakan/id/talentpool/unit/service/RecommendationServiceTest.java
@@ -288,51 +288,99 @@ class RecommendationServiceTest {
     }
 
     @Nested
-    class DeleteRecommendation{
-        @Test
-        void deleteById_Success() {
-            when(recommendationRepository.findById(recommendation1.getId())).thenReturn(Optional.of(recommendation1));
-            User mockedTalent = mock(User.class);
-            recommendation1.setTalent(mockedTalent);
-            when(mockedTalent.getId()).thenReturn("idUser");
-            RecommendationResponseDTO response = recommendationService.deleteById( "idUser", recommendation1.getId());
+    class DeleteRecommendation {
 
-            verify(recommendationRepository, times(1)).deleteById(recommendation1.getId());
+        @Nested
+        class DeleteByIdTalent {
 
-            assertNotNull(response);
-            assertEquals(recommendation1.getId(), response.getId());
-            assertEquals(StatusType.PENDING, response.getStatus());
+            @Test
+            void deleteByIdTalent_Success() {
+                when(recommendationRepository.findById(recommendation1.getId())).thenReturn(Optional.of(recommendation1));
+                User mockedTalent = mock(User.class);
+                recommendation1.setTalent(mockedTalent);
+                when(mockedTalent.getId()).thenReturn("idUser");
+
+                RecommendationResponseDTO response = recommendationService.deleteByIdTalent("idUser", recommendation1.getId());
+
+                verify(recommendationRepository, times(1)).deleteById(recommendation1.getId());
+
+                assertNotNull(response);
+                assertEquals(recommendation1.getId(), response.getId());
+                assertEquals(StatusType.PENDING, response.getStatus());
+            }
+
+            @Test
+            void deleteByIdTalent_NotFound_ThrowsException() {
+                when(recommendationRepository.findById("999")).thenReturn(Optional.empty());
+
+                EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+                    recommendationService.deleteByIdTalent("userId", "999");
+                });
+
+                assertEquals("Recommendation with id 999 not found.", exception.getMessage());
+                verify(recommendationRepository, never()).deleteById("999");
+            }
+
+            @Test
+            void deleteByIdTalent_UnAuthorized_ThrowsException() {
+                User mockedTalent = mock(User.class);
+                recommendation1.setTalent(mockedTalent);
+                when(mockedTalent.getId()).thenReturn("idUser");
+                when(recommendationRepository.findById(eq(recommendation1.getId()))).thenReturn(Optional.of(recommendation1));
+
+                AccessDeniedException exception = assertThrows(AccessDeniedException.class, () -> {
+                    recommendationService.deleteByIdTalent("unauthorizedUserId", recommendation1.getId());
+                });
+
+                assertEquals("You are not allowed to delete this recommendation.", exception.getMessage());
+                verify(recommendationRepository, never()).deleteById(any());
+            }
         }
-        @Test
-        void deleteById_NotFound_ThrowsException() {
 
-            when(recommendationRepository.findById("999")).thenReturn(Optional.empty());
-            EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
-                recommendationService.deleteById("userId","999");
-            });
+        @Nested
+        class DeleteByIdContractor {
 
-            assertEquals("Recommendation with id 999 not found.", exception.getMessage());
+            @Test
+            void deleteByIdContractor_Success() {
+                recommendation1.setContractorId(123L);
+                when(recommendationRepository.findById(recommendation1.getId())).thenReturn(Optional.of(recommendation1));
 
-            verify(recommendationRepository, never()).deleteById("999");
-        }
+                RecommendationResponseDTO response = recommendationService.deleteByIdContractor(123L, recommendation1.getId());
 
-        @Test
-        void testDeleteById_UnAuthorized() {
-            // Arrange
-            User mockedTalent = mock(User.class);
-            recommendation1.setTalent(mockedTalent);
-            when(mockedTalent.getId()).thenReturn("idUser");
-            when(recommendationRepository.findById(eq(recommendation1.getId()))).thenReturn(Optional.of(recommendation1));
+                verify(recommendationRepository, times(1)).deleteById(recommendation1.getId());
 
-            // Act & Assert
-            AccessDeniedException exception = assertThrows(AccessDeniedException.class, () -> {
-                recommendationService.deleteById("idUser123", recommendation1.getId());
-            });
+                assertNotNull(response);
+                assertEquals(recommendation1.getId(), response.getId());
+                assertEquals(StatusType.PENDING, response.getStatus());
+            }
 
-            assertEquals("You are not allowed to delete this recommendation.", exception.getMessage());
-            verify(recommendationRepository, never()).save(any());
+            @Test
+            void deleteByIdContractor_NotFound_ThrowsException() {
+                when(recommendationRepository.findById("999")).thenReturn(Optional.empty());
+
+                EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+                    recommendationService.deleteByIdContractor(123L, "999");
+                });
+
+                assertEquals("Recommendation with id 999 not found.", exception.getMessage());
+                verify(recommendationRepository, never()).deleteById(any());
+            }
+
+            @Test
+            void deleteByIdContractor_Unauthorized_ThrowsException() {
+                recommendation1.setContractorId(999L);
+                when(recommendationRepository.findById(recommendation1.getId())).thenReturn(Optional.of(recommendation1));
+
+                AccessDeniedException exception = assertThrows(AccessDeniedException.class, () -> {
+                    recommendationService.deleteByIdContractor(123L, recommendation1.getId());
+                });
+
+                assertEquals("You are not allowed to delete this recommendation.", exception.getMessage());
+                verify(recommendationRepository, never()).deleteById(any());
+            }
         }
     }
+
     @Nested
     class patchStatus{
 


### PR DESCRIPTION
# Description  
I split the delete recommendation endpoint into two: one for the talent to delete a recommendation, and another for the contractor.

# Ticket Issue 
https://a-man-ppl.atlassian.net/browse/AMAN-151

# Changes Made  
I split the delete recommendation endpoint into two: one for the talent to delete a recommendation, and another for the contractor.

# Issue Type
- [ ] 🐛 Bug fix 
- [ ] ⚙️ Refactor
- [X] 💻 New feature 
- [ ] 📄 Documentation update
- [ ] ⚠️ Breaking changes
- [ ] 🔍 Testing

# Added/updated tests?
<!--We encourage you to keep the code coverage percentage at 80% and above-->
- [X] Yes
- [ ] No, and this is why: [please replace this line with details on why tests have not been included]

# Additional Notes  
None

# (optional) What photo/gif best describes this PR or how it makes you feel?
![image](https://github.com/user-attachments/assets/4456776c-12d0-4469-b7b1-bf29b95f7371)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for contractors to delete recommendations using their contractor ID.
- **Bug Fixes**
  - Improved authorization checks and error handling when deleting recommendations, ensuring only authorized users can perform deletions.
- **Tests**
  - Expanded and reorganized tests to cover deletion of recommendations by both talent users and contractors, including success, not found, and unauthorized scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->